### PR TITLE
Instructor not allowed to edit content while evaluating student work

### DIFF
--- a/client/src/inside/components/page/ehr-helper.js
+++ b/client/src/inside/components/page/ehr-helper.js
@@ -121,6 +121,10 @@ export default class EhrHelpV2 {
   }
 
   _canEdit () {
+    if(StoreHelper.isInstructor() && !StoreHelper.isSeedEditing()) {
+      // the instructor is evaluating student work. Do not allow edit of content.
+      return false
+    }
     let studentCanEdit = this._isActivityOpen() && this._isStudent() && !this._isSubmitted()
     return studentCanEdit || this._isDevelopingContent()
   }


### PR DESCRIPTION
While instructors are evaluating student's work they should not to be able to edit that work. 