### PR TITLE
Fix issues with unlinked activities

### DIFF
--- a/client/src/helpers/store-helper.js
+++ b/client/src/helpers/store-helper.js
@@ -212,23 +212,12 @@ class StoreHelperWorker {
   getActivityId () { return this._getActivityProperty('activityId') }
 
   getActivityTitle () { return this._getActivityProperty('activityTitle') }
-
   getActivityDescription () { return this._getActivityProperty('activityDescription') }
-
-  activitiesUsingAssignmentCount (assignmentId) {
-    let cnt = 0
-    let courses = this.getCourseList()
-    courses.forEach(course => {
-      course.activities.forEach( a => cnt += a.assignment === assignmentId ? 1 : 0)
-    })
-    return cnt
-  }
-
   lmsActivitiesUsingLearningObject (lObjId) {
     let list = []
     let courses = this.getCourseList()
     courses.forEach(course => {
-      let clist = course.activities.filter( a => a.assignment._id === lObjId)
+      let clist = course.activities.filter( a => a.assignment && a.assignment._id === lObjId)
       list = [...list, ...clist]
     })
     return list

--- a/client/src/outside/components/learning-object/LearningObjectActions.vue
+++ b/client/src/outside/components/learning-object/LearningObjectActions.vue
@@ -47,9 +47,6 @@ export default {
   computed: {
     activityCount () { return this.learningObject.activityCount},
     canDo () { return StoreHelper.isDevelopingContent() },
-    activityList () {
-      return StoreHelper.lmsActivitiesUsingLearningObject(this.learningObject._id)
-    },
     learningObjectId () { return this.learningObject._id}
   },
   methods: {

--- a/client/src/outside/components/learning-object/LearningObjectSelectItem.vue
+++ b/client/src/outside/components/learning-object/LearningObjectSelectItem.vue
@@ -4,7 +4,7 @@
       div(class="list-item-name") {{lObj.name}} &nbsp;
         a(@click="showMore = !showMore") {{showMore ? 'show less' : 'show more'}}
       div
-        ui-button(v-on:buttonClicked="selectLearningObject(lObj)", class='link-button') Connect to activity
+        ui-button(v-on:buttonClicked="selectLearningObject(lObj)", class='link-button') Connect to this activity
         ui-confirm(ref="confirmDialog", saveLabel="Connect", v-on:confirm="proceed(lObj)", html-body=true)
     div(v-if="showMore")
       div(class="details-row")

--- a/client/src/outside/components/lms-activity/ClassListItem.vue
+++ b/client/src/outside/components/lms-activity/ClassListItem.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   div(class="list-item-container")
     div(class="list-item-name") {{studentName}} &nbsp;
-    class-list-actions(:studentVisit='studentVisit')
+    class-list-actions(v-if='hasLinkedLearningObject', :studentVisit='studentVisit')
     div(class="flow_across")
       div(class="details-name") {{text.EVALUATION}}
       div(class="details-value") {{ evaluationNotes }}
@@ -26,7 +26,9 @@ export default {
     studentVisit: {type: Object}
   },
   computed: {
-    studentName () { return this.studentVisit.user.fullName },
+    activity () {
+      return this.$store.getters['activityStore/activity']
+    },
     activityData () { return this.studentVisit.activityData},
     assignment () { return this.$store.getters['assignmentStore/assignment']},
     evaluationNotes () {
@@ -34,7 +36,9 @@ export default {
       const lim = 100
       return this.showMore ? txt : (txt.length > lim ? txt.substr(0, lim) + '...' : txt)
     },
+    hasLinkedLearningObject () { return this.activity.assignment },
     showLabels () { return StoreHelper.isOutsideShowButtonLabels() },
+    studentName () { return this.studentVisit.user.fullName },
   },
   methods: {
     statusText () {

--- a/client/src/outside/components/lms-course/CourseActivityListItem.vue
+++ b/client/src/outside/components/lms-course/CourseActivityListItem.vue
@@ -36,9 +36,15 @@
       div(class="details-row")
         div(class="details-name") {{text.LOBJ}}
         div(class="details-value")
-          ui-link(:name="'learning-object'", :query="{learningObjectId: assignment._id}")
-            fas-icon(class='fa', :icon='appIcons.lobj')
-            span &nbsp; {{ assignment.name }}
+          div(v-if='hasLinkedLearningObject')
+            ui-link(:name="'learning-object'", :query="{learningObjectId: assignment._id}")
+              fas-icon(class='fa', :icon='appIcons.lobj')
+              span &nbsp; {{ assignment.name }}
+          div(v-else)
+            div No learning object is linked to this activity
+            ui-button(v-on:buttonClicked='goToUnlinked')
+              slot(name="save-button") Connect learning object to this activity.
+
       div(class="details-row")
         div(class="details-name") {{text.CLASS_LIST}}
         div(class="details-value")
@@ -48,17 +54,21 @@
       div(class="details-row")
         div(class="details-name") {{text.CASE_STUDY}}
         div(class="details-value")
-          ui-link(name="seed-view", :query="{seedId: caseStudy._id}")
-            fas-icon(class='fa', :icon='appIcons.seed')
-            span &nbsp; {{ caseStudy.name }}
+          div(v-if='hasLinkedLearningObject')
+            ui-link(name="seed-view", :query="{seedId: caseStudy._id}")
+              fas-icon(class='fa', :icon='appIcons.seed')
+              span &nbsp; {{ caseStudy.name }}
+          div(v-else) No learning object is linked to this activity
 </template>
 
 <script>
 import { APP_ICONS } from '@/helpers/app-icons'
 import UiLink from '@/app/ui/UiLink'
 import { Text } from '@/helpers/ehr-text'
+import { UNLINKED_ACTIVITY_ROUTE_NAME } from '@/router'
+import UiButton from '@/app/ui/UiButton.vue'
 export default {
-  components: { UiLink, },
+  components: { UiButton, UiLink, },
   data () {
     return {
       appIcons: APP_ICONS,
@@ -72,10 +82,15 @@ export default {
     showIds: { type: Boolean }
   },
   computed: {
+    activityId () { return this.activity._id },
     assignment () { return this.activity.assignment || {} },
+    hasLinkedLearningObject () { return this.activity.assignment },
     caseStudy () { return this.activity.caseStudy || {} }
   },
   methods: {
+    goToUnlinked () {
+      this.$router.push({ name: UNLINKED_ACTIVITY_ROUTE_NAME, query: { activityId: this.activityId } })
+    },
     truncate (input, lim) {
       return input.length > lim ? `${input.substring(0, lim)}...` : input }
   }

--- a/client/src/outside/components/lms-course/CourseActivityStudentListItem.vue
+++ b/client/src/outside/components/lms-course/CourseActivityStudentListItem.vue
@@ -61,7 +61,8 @@ export default {
   computed: {
     activity () { return this.data.activity },
     activityData () { return this.data.activityData },
-    assignment () { return this.data.assignment },
+    // rarely the activity may still lack a link to an assignement. it is "unlinked"
+    assignment () { return this.data.assignment || {}},
     scratchData () { return this.data.activityData.scratchData },
     submitted () { return this.activityData.submitted },
     visit () { return this.data.visit },

--- a/client/src/outside/views/ClassList.vue
+++ b/client/src/outside/views/ClassList.vue
@@ -13,10 +13,11 @@
       div(class="details-row")
         div(class="details-name") {{text.LOBJ}}
         div(class="details-value")
-          ui-link(:name="'learning-object'", :query="{learningObjectId: assignment._id}")
-            fas-icon(class='fa', :icon='appIcons.lobj')
-            span &nbsp; {{ assignment.name }}
-
+          div(v-if='hasLinkedLearningObject')
+            ui-link(:name="'learning-object'", :query="{learningObjectId: assignment._id}")
+              fas-icon(class='fa', :icon='appIcons.lobj')
+              span &nbsp; {{ assignment.name }}
+          div(v-else) No learning object is linked to this activity
     div(class="classlist-body")
       div(v-if="classList.length===0") No students have attempted this activity.
       div(v-else, v-for="(studentVisit) in classList", class="list-card list-element", :class="rowClass(studentVisit)")
@@ -53,11 +54,12 @@ export default {
       return this.activity.resource_link_title
     },
     assignment () {
-      return this.$store.getters['assignmentStore/assignment']
+      return this.$store.getters['assignmentStore/assignment'] || {}
     },
     classList () {
       return StoreHelper.getClassList()
     },
+    hasLinkedLearningObject () { return this.activity.assignment },
     showLabels () { return StoreHelper.isOutsideShowButtonLabels() },
   },
   methods: {

--- a/client/src/outside/views/UnlinkedActivity.vue
+++ b/client/src/outside/views/UnlinkedActivity.vue
@@ -16,7 +16,7 @@
       p.
         The activity you selected, in your learning management system, is not yet linked to a learning object.
         Please select a learning object from the list below and connect it to this activity.  You must do this before
-        any student needs to use this activity.
+        any student can use this activity.
 
     div(class='row-flow')
       p Activity: {{ activity.resource_link_title }}

--- a/client/src/store/modules/assignmentListStore.js
+++ b/client/src/store/modules/assignmentListStore.js
@@ -45,6 +45,8 @@ const actions = {
   },
 
 
+  // TODO  remove the following and replace with the loadAssignmentsWithCounts
+  // because the create and update use the following but most other parts of the system use the with counts
   async loadAssignments (context) {
     const { dispatch, commit } = context
     const list = await dispatch('getAssignments', context)

--- a/server/src/mcr/user/user-controller.js
+++ b/server/src/mcr/user/user-controller.js
@@ -53,10 +53,11 @@ export default class UserController extends BaseController {
                 // decouple from mongoose so we can add in case study
                 activity = JSON.parse(JSON.stringify(activity))
                 const assignment = activity.assignment
-                const sId = assignment.seedDataId
-                const seed = seedList.find(item => item._id === sId)
-                activity['caseStudy'] = seed
-
+                if (assignment) {
+                  const sId = assignment.seedDataId
+                  const seed = seedList.find(item => item._id === sId)
+                  activity['caseStudy'] = seed
+                }
                 // group by course
                 let cId = activity.context_id
                 let course = courses.find(c => c.id === cId)
@@ -186,12 +187,12 @@ export default class UserController extends BaseController {
       const studentActivity = {
         visit: visit,
         activityData: visit.activityData,
-        assignmentData: visit.activityData.assignmentData,
+        assignmentData: visit.activityData ? visit.activityData.assignmentData : undefined,
         activity: activity,
         assignment: activity.assignment
       }
-      studentActivity.visit.activityData = visit.activityData._id
-      studentActivity.activity.assignment = activity.assignment._id
+      visit.activityData ? studentActivity.visit.activityData = visit.activityData._id : null
+      activity.assignment ? studentActivity.activity.assignment = activity.assignment._id : null
       course.courseActivities.push(studentActivity)
     }
     // console.log('Return this course list', JSON.stringify(courses, null, 2))


### PR DESCRIPTION
Found that it is possible for activities to be unlinked to learning objects. This was not expected so there were many places in the code that assumed every Activity had a link to a Learning Object (called assignment in the code).  This PR addresses this situation and allows instructor users make connections for unlinked activities.