### PR TITLE
Fix Safari

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2678,6 +2678,27 @@
         "whatwg-fetch": "^3.6.2"
       },
       "dependencies": {
+        "@vue/vue-loader-v15": {
+          "version": "npm:vue-loader@15.10.1",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
+          "integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
+          "dev": true,
+          "requires": {
+            "@vue/component-compiler-utils": "^3.1.0",
+            "hash-sum": "^1.0.2",
+            "loader-utils": "^1.1.0",
+            "vue-hot-reload-api": "^2.3.0",
+            "vue-style-loader": "^4.1.0"
+          },
+          "dependencies": {
+            "hash-sum": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+              "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
+              "dev": true
+            }
+          }
+        },
         "acorn-walk": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -2777,27 +2798,6 @@
       "requires": {
         "dom-event-types": "^1.0.0",
         "lodash": "^4.17.4"
-      }
-    },
-    "@vue/vue-loader-v15": {
-      "version": "npm:vue-loader@15.10.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
-      "integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
-      "dev": true,
-      "requires": {
-        "@vue/component-compiler-utils": "^3.1.0",
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.1.0",
-        "vue-hot-reload-api": "^2.3.0",
-        "vue-style-loader": "^4.1.0"
-      },
-      "dependencies": {
-        "hash-sum": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
-          "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
-          "dev": true
-        }
       }
     },
     "@vue/vue2-jest": {
@@ -5055,11 +5055,6 @@
       "requires": {
         "ms": "2.1.2"
       }
-    },
-    "decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA=="
     },
     "decamelize-keys": {
       "version": "1.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,6 @@
     "axios": "^0.21.4",
     "bulma": "^0.9.3",
     "core-js": "^3.8.3",
-    "decamelize": "^6.0.0",
     "exif-js": "^2.3.0",
     "file-saver": "^2.0.5",
     "filesize": "^8.0.7",

--- a/client/src/ehr-definitions/ehr-checkset.js
+++ b/client/src/ehr-definitions/ehr-checkset.js
@@ -1,9 +1,44 @@
 import camelcase from 'camelcase'
-import decamelize from 'decamelize'
+// import decamelize from 'decamelize'
 import StoreHelper from '@/helpers/store-helper'
 import { isString } from '@/helpers/ehr-utils'
 import { Text } from '@/helpers/ehr-text'
 import EhrDefs from '@/helpers/ehr-defs-grid'
+
+
+function decamelize (
+  text,
+  {
+    separator = '_',
+  } = {},
+) {
+  if (!(typeof text === 'string' && typeof separator === 'string')) {
+    throw new TypeError(
+      'The `text` and `separator` arguments should be of type `string`',
+    )
+  }
+
+  const replacement = `$1${separator}$2`
+
+  // Split lowercase sequences followed by uppercase character.
+  // `dataForUSACounties` → `data_For_USACounties`
+  // `myURLstring → `my_URLstring`
+  const decamelized = text.replace(
+    /([\p{Lowercase_Letter}\d])(\p{Uppercase_Letter})/gu,
+    replacement,
+  )
+
+  // Split multiple uppercase characters followed by one or more lowercase characters.
+  // `my_URLstring` → `my_ur_lstring`
+  return decamelized
+    .replace(
+      /(\p{Uppercase_Letter})(\p{Uppercase_Letter}\p{Lowercase_Letter}+)/gu,
+      replacement,
+    )
+    .toLowerCase()
+}
+
+
 
 export default class EhrCheckset {
   static dbValueToCheckSet (value) {


### PR DESCRIPTION
Safari does not support RegExp Lookbehind. The decamelize library uses this form of RegExp. To fix I removed the decamelize library from client and copied the little bit of code into the ehr-checkset.js file.