### PR TITLE
Condensed view collapsible tables

### DIFF
--- a/client/src/outside/components/seed-struct/SeedPage.vue
+++ b/client/src/outside/components/seed-struct/SeedPage.vue
@@ -2,24 +2,26 @@
   div(class="seed-page")
     div(v-if='pageElement.isTable')
       div(class="flow_across")
-        zone-lms-button(@action="toggleTableOrientation"
-          class="flow_across_last_item"
-          :title="`Rotate the table ${tableOrientation ? 'vertical' : 'horizontal'}`",
-          :icon='appIcons.table',
-          :icon-class='{rotatedIcon: tableOrientation}',
+        div {{ pageElement.label }}
+        zone-lms-button(@action="tableCollapsed = !tableCollapsed"
+          class="flow_across_last_item mr5"
+          title="Collapse the table",
+          :icon='tableCollapsed ? "chevron-down" : "chevron-up"',
           text="")
-      seed-table-horiz(v-show='tableOrientation',
-        :pageKey="pageKey",
-        :pageChildren="pageChildren",
-        :pageElement='pageElement',
-        :pageSeedData='pageSeedData'
-      )
-      seed-table-vert(v-show='!tableOrientation',
-        :pageKey="pageKey",
-        :pageChildren="pageChildren",
-        :pageElement='pageElement',
-        :pageSeedData='pageSeedData'
-      )
+      transition(name="fade" mode="out-in")
+        div(v-show="!tableCollapsed")
+          seed-table-horiz(v-show='tableOrientation',
+            :pageKey="pageKey",
+            :pageChildren="pageChildren",
+            :pageElement='pageElement',
+            :pageSeedData='pageSeedData'
+          )
+          seed-table-vert(v-show='!tableOrientation',
+            :pageKey="pageKey",
+            :pageChildren="pageChildren",
+            :pageElement='pageElement',
+            :pageSeedData='pageSeedData'
+          )
     div(v-if='pageElement.isPageForm')
       div(v-for='group in pageElement.ehr_groups')
         div(v-for='child in group.gChildren')
@@ -39,7 +41,8 @@ export default {
   components: { SeedTableHoriz, ZoneLmsButton, SeedFormElement, SeedTableVert },
   data () {
     return {
-      appIcons: APP_ICONS
+      appIcons: APP_ICONS,
+      tableCollapsed: false
     }
   },
   props: {
@@ -58,10 +61,6 @@ export default {
     getSeedData (eKey) {
       return this.pageSeedData[eKey]
     },
-    toggleTableOrientation () {
-      const value = this.tableOrientation
-      this.$store.dispatch('system/setCondensedTableVertical', !value)
-    }
   }
 }
 </script>
@@ -76,4 +75,14 @@ export default {
 .seed-page{
   margin-bottom: 3rem;
 }
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity .3s
+}
+.fade-enter,
+.fade-leave-to {
+  opacity: 0
+}
+
 </style>

--- a/client/src/outside/components/seed-struct/SeedStructural.vue
+++ b/client/src/outside/components/seed-struct/SeedStructural.vue
@@ -7,16 +7,31 @@
           :activePageKey='activePageKey',
           :ehrData='ehrData')
       div(class="smaller-than-900")
+        div(class="flow_across")
+          zone-lms-button(@action="toggleTableOrientation"
+            class="flow_across_last_item mr5"
+            :title="`Rotate the table ${tableOrientation ? 'vertical' : 'horizontal'}`",
+            :icon='appIcons.table',
+            :icon-class='{rotatedIcon: tableOrientation}',
+            text="")
         h2(class="smaller-than-900")
           fas-icon(:icon="appIcons.menu", @click="showingNavPanel = !showingNavPanel")
           span &nbsp; {{pageTitle}}
+
         transition(name="hamburger-action")
           seed-menus(v-if="showingNavPanel",
             @selectPage="selectPage",
             :activePageKey='activePageKey',
             :ehrData='ehrData')
     div(class="ehrData-details")
-      h2(class="bigger-screens-900") {{pageTitle}}
+      div(class="flow_across")
+        h2(class="bigger-screens-900") {{pageTitle}}
+        zone-lms-button(@action="toggleTableOrientation"
+          class="flow_across_last_item mr5"
+          :title="`Rotate the table ${tableOrientation ? 'vertical' : 'horizontal'}`",
+          :icon='appIcons.table',
+          :icon-class='{rotatedIcon: tableOrientation}',
+          text="")
       seed-pages(
         :pageKey="activePageKey",
         :pageDef="pageDef",
@@ -28,8 +43,9 @@ import SeedPages from '@/outside/components/seed-struct/SeedPages'
 import SeedMenus from '@/outside/components/seed-struct/SeedMenus'
 import EhrDefs from '@/helpers/ehr-defs-grid'
 import { APP_ICONS } from '@/helpers/app-icons'
+import ZoneLmsButton from '@/outside/components/ZoneLmsButton.vue'
 export default {
-  components: { SeedPages, SeedMenus },
+  components: { ZoneLmsButton, SeedPages, SeedMenus },
   data () {
     return {
       appIcons: APP_ICONS,
@@ -49,11 +65,7 @@ export default {
       const pkey = this.activePageKey
       return this.ehrData ? (pkey ? this.ehrData[pkey] : {}) : {}
     },
-  },
-  watch: {
-    ehrData: function () {
-      this.setInitialPage()
-    }
+    tableOrientation () { return this.$store.getters['system/condensedTableVertical']},
   },
   methods: {
     selectPage ( key ) {
@@ -72,6 +84,15 @@ export default {
         console.log('ehrData structure without data. Why?')
       }
     },
+    toggleTableOrientation () {
+      const value = this.tableOrientation
+      this.$store.dispatch('system/setCondensedTableVertical', !value)
+    }
+  },
+  watch: {
+    ehrData: function () {
+      this.setInitialPage()
+    }
   },
 }
 </script>

--- a/client/src/scss/_definitions.scss
+++ b/client/src/scss/_definitions.scss
@@ -118,3 +118,7 @@ $o-wrapper-sizes: (
   padding-left: 0;
   max-width: map-get($o-wrapper-sizes, $size);
 }
+
+.mr5 {
+  margin-right: 5px
+}


### PR DESCRIPTION
On the condensed EHR view allow user to collapse table. This is important when a page has two or more tables and the orientation is vertical
