### PR TITLE
Vue client central error handler, tweak Sentry settings

### DIFF
--- a/client/src/app/components/AppFooter.vue
+++ b/client/src/app/components/AppFooter.vue
@@ -21,6 +21,8 @@
     div(class="footer-section")
       div {{ apiData.appTitle }}
       div {{ authData.timeRemaining }}
+    div(class="error-testing")
+      button(@click="throwError")  error testing
 </template>
 
 <script>
@@ -45,6 +47,11 @@ export default {
     showEdEhrOrg () {
       return edherorg.isEdEhrOrg()
     },
+  },
+  methods: {
+    throwError () {
+      throw new Error('Sentry Error')
+    }
   }
 }
 </script>
@@ -65,5 +72,9 @@ footer {
   .footer-section {
     margin-bottom: 1rem;
   }
+}
+.error-testing button {
+  background-color: transparent;
+  color: black
 }
 </style>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -18,9 +18,6 @@ Import the global style sheet
  */
 import './scss/styles.scss'
 import StoreHelper from '@/helpers/store-helper'
-
-
-
 /*
 Configure Vue
  */
@@ -33,6 +30,23 @@ Vue.component('home-layout', homeLayout)
 Vue.component('outside-layout', outsideLayout)
 Vue.component('lms-layout', lmsLayout)
 Vue.component('inside-layout', insideLayout)
+
+/**
+ * Global catch for errors that are thrown during Vue processing. For example, the main Vue render
+ * process has no other central way to catch and record errors.
+ *
+ * This handler prints a message to the error console. Sentry is configured to create an event
+ * on every time the error console is used.
+ *
+ * @param err - the error object that got thrown
+ * @param vm
+ * @param info - where in the Vue world did the error happen. In a lifecylce event? during render?
+ */
+Vue.config.errorHandler = function (err, vm, info)  {
+  const msg = '[Global Error Handler]: Error in (' + info + '): (' + err.message + ')'
+  console.error(msg)
+  // Sentry.captureMessage(msg,data)
+}
 
 router.afterEach(async (to, from) => {
   let startTime = performance.now()
@@ -57,7 +71,7 @@ if (!window.location.origin.includes('localhost')) {
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
-    tracesSampleRate: 0.7,
+    tracesSampleRate: 0.05,
   })
 }
 /*

--- a/server/src/config/config.js
+++ b/server/src/config/config.js
@@ -5,7 +5,7 @@ import { version } from 'process'
 import { logError} from '../helpers/log-error'
 const debug = require('debug')('server')
 
-if (version.includes('v14')) {
+if (version.includes('v14') || version.includes('v18')) {
   debug(`Node Version: ${version}`)
 } else {
   logError('Unexpected version of Node is active ', version)
@@ -70,7 +70,7 @@ function defaultConfig (env) {
     sentryDsn: process.env.SENTRY_DSN,
     // Use this hard coded value on a temporary basis on localhost. you do this to test sentry
     // sentryDsn: 'https://cab9cdff46224d679f1cb5d9a24c643d@o1411884.ingest.sentry.io/6756187',
-    sentryTraceRate: process.env.SENTRY_TRACES_SAMPLE_RATE || 0.7, // default to 70%
+    sentryTraceRate: process.env.SENTRY_TRACES_SAMPLE_RATE || 0.05, // default to 5%
   }
 }
 


### PR DESCRIPTION
Reduce sentry sampling rates to avoid transaction overusage.
Add a means to test throwing an error on the client.
