### PR TITLE
Change docker volume declaration

### DIFF
--- a/deployment/d-c.yml
+++ b/deployment/d-c.yml
@@ -76,6 +76,6 @@ services:
       - "${MONGODB_PORT}:${MONGODB_PORT}"
     command: mongod --port ${MONGODB_PORT}
     volumes:
-      - "${VOLUME_STORAGE}/scripts:/data/scripts"
-      - "${VOLUME_STORAGE}/data:/data/db"
-      - "${VOLUME_STORAGE}/backups:/data/backups"
+      - "${STORAGE_DB_SCRIPTS}:/data/scripts"
+      - "${STORAGE_DATABASE}:/data/db"
+      - "${STORAGE_BACKUPS}:/data/backups"

--- a/deployment/env-check.js
+++ b/deployment/env-check.js
@@ -26,10 +26,14 @@ toCheck.forEach( v => globalValid = globalValid && testExists(v, true) )
 
 if (testExists('NODE_ENV=production')) {
   console.log('production')
-  globalValid = globalValid && testExists('VOLUME_STORAGE=/')
+  globalValid = globalValid && testExists('STORAGE_BACKUPS=/')
+  globalValid = globalValid && testExists('STORAGE_DB_SCRIPTS=/')
+  globalValid = globalValid && testExists('STORAGE_DATABASE=/')
 } else if (testExists('NODE_ENV=development')) {
   console.log('development')
-  globalValid = globalValid && testExists('VOLUME_STORAGE=')
+  globalValid = globalValid && testExists('STORAGE_BACKUPS=')
+  globalValid = globalValid && testExists('STORAGE_DB_SCRIPTS=')
+  globalValid = globalValid && testExists('STORAGE_DATABASE=')
 } else {
   console.log('Unexpected value in NODE_ENV')
   globalValid = false

--- a/deployment/sample.env.site
+++ b/deployment/sample.env.site
@@ -5,7 +5,6 @@ COOKIE_SECRET=changeThisCookieSecretOnProduction
 MONGODB_PWORD=protectTheDatabase
 DOMAIN=edehr.org
 APP_TITLE=titleShownOnBrowserTab
-
-VOLUME_STORAGE=/mnt/volume_tor1_01
-VOLUME_STORAGE=../database
-VOLUME_STORAGE=../database/docker-dev
+STORAGE_BACKUPS=../database/backups
+STORAGE_DB_SCRIPTS=../database/scripts
+STORAGE_DATABASE=../database/database

--- a/edehr.org/scripts_edehr/edehr_db_backup.sh
+++ b/edehr.org/scripts_edehr/edehr_db_backup.sh
@@ -14,8 +14,8 @@ if [[ -z "$MONGODB_PWORD" ]]; then
     echo Must provide the /opt/edehr/project/deployment/.env.site file with MONGODB_PWORD
     exit
 fi
-if [[ -z "$VOLUME_STORAGE" ]]; then
-    echo Must provide the /opt/edehr/project/deployment/.env.site file with VOLUME_STORAGE
+if [[ -z "STORAGE_BACKUPS" ]]; then
+    echo Must provide the .env.site file with STORAGE_BACKUPS
     exit
 fi
 
@@ -32,7 +32,7 @@ fi
 # Location withing the docker container
 dArchive="/data/backups/${fName}"
 # Location in the file system.
-sArchive="${VOLUME_STORAGE}/backups/${fName}"
+sArchive="${STORAGE_BACKUPS}/${fName}"
 
 docker exec $ddb mongodump --db $dbName --authenticationDatabase admin -u root --archive=$dArchive --gzip --password=$MONGODB_PWORD
 echo "The new back up file is ${sArchive}"

--- a/edehr.org/scripts_edehr/edehr_db_restore.sh
+++ b/edehr.org/scripts_edehr/edehr_db_restore.sh
@@ -13,8 +13,8 @@ if [[ -z "$MONGODB_PWORD" ]]; then
     echo Must provide the /opt/edehr/project/deployment/.env.site file with MONGODB_PWORD
     exit
 fi
-if [[ -z "$VOLUME_STORAGE" ]]; then
-    echo Must provide the /opt/edehr/project/deployment/.env.site file with VOLUME_STORAGE
+if [[ -z "STORAGE_BACKUPS" ]]; then
+    echo Must provide the .env.site file with STORAGE_BACKUPS
     exit
 fi
 
@@ -26,7 +26,7 @@ if [[ -z "$ddb" ]]; then
 fi
 
 # Location in the file system.
-sArchive="${VOLUME_STORAGE}/backups/${fName}"
+sArchive="${STORAGE_BACKUPS}/${fName}"
 
 if [ -e ${sArchive} ]
 then


### PR DESCRIPTION
Split the docker volumes used by the database container into three to allow for changing one without affecting the others.  For example, to be able to set the location of the backup files into a different location that the database itself.