### PR TITLE
Websocket single event listener

### DIFF
--- a/client/src/helpers/axios-helper.js
+++ b/client/src/helpers/axios-helper.js
@@ -1,13 +1,40 @@
 import axios from 'axios'
-// import authHelper from '@/helpers/auth-helper'
-import EventBus, { USER_LOGIN_EVENT } from '@/helpers/event-bus'
+import authHelper from '@/helpers/auth-helper'
+import EventBus, { USER_LOGIN_EVENT, USER_LOGOUT_EVENT } from '@/helpers/event-bus'
 
+const PX = 'Axios helper --- '
+
+/**
+ * Set or clear the Authorization header AND emit appropriate log in or log out events.
+ *
+ * @param token
+ */
 export const setAuthHeader = (token) => {
-  //console.log('setAuthHeader', authHelper.hashToken(token))
+  const newHash = authHelper.hashToken(token)
+  const currentAuth = axios.defaults.headers['Authorization']
+  let existingHash = currentAuth ? authHelper.hashToken(currentAuth.replace('Bearer ', '')) : undefined
   if (token) {
-    axios.defaults.headers['Authorization'] = `Bearer ${token}`
-    EventBus.$emit(USER_LOGIN_EVENT)
+    if (existingHash === newHash) {
+      if (debug) console.log(PX + 'new is same as old so do nothing')
+    } else {
+      if (debug) console.log(PX + 'old and new are different', existingHash, newHash)
+      // Note that the token changes when the user selects a new Activity from any Course.
+      // As well, of course, when the user enters via LTI
+      if(existingHash) {
+        if (debug) console.log(PX + 'emit logout event')
+        axios.defaults.headers['Authorization'] = null
+        EventBus.$emit(USER_LOGOUT_EVENT)
+      }
+      if (debug) console.log(PX + 'set axios Authorization header to the new token', newHash)
+      axios.defaults.headers['Authorization'] = `Bearer ${token}`
+      if (debug) console.log(PX + 'emit login event')
+      EventBus.$emit(USER_LOGIN_EVENT)
+    }
   } else {
     axios.defaults.headers['Authorization'] = null
+    if(existingHash) {
+      if (debug) console.log(PX + 'emit logout event')
+      EventBus.$emit(USER_LOGOUT_EVENT)
+    }
   }
 }

--- a/client/src/helpers/page-controller.js
+++ b/client/src/helpers/page-controller.js
@@ -103,7 +103,7 @@ async  function onPageChange (toRoute) {
         // Need to clear away that full demo....
         if (dbApp) console.log('Actual LTI request needs to stop full demo. Will log user out without adieu.')
         // TODO.  Alert the user and offer to keep the demo data and stop the LTI log in.
-        await StoreHelper.logUserOutOfEdEHR()
+        await StoreHelper.exitFullDemo()
         haveDemoToken = !!StoreHelper.getDemoToken()
       }
       if (dbApp) console.log('on new auth we need to clear out previous visit id')

--- a/client/src/helpers/store-helper.js
+++ b/client/src/helpers/store-helper.js
@@ -3,7 +3,6 @@ import { removeEmptyProperties } from './ehr-utils'
 import sKeys from './session-keys'
 import { ZONE_ADMIN, ZONE_DEMO, ZONE_EHR, ZONE_LMS, ZONE_PUBLIC } from '@/router'
 import EhrOnlyDemo from '@/helpers/ehr-only-demo'
-import EventBus, { USER_LOGOUT_EVENT } from '@/helpers/event-bus'
 
 let debugSH = false
 
@@ -630,13 +629,12 @@ class StoreHelperWorker {
     return this._getAuthStore('visitId')
   }
 
-  async logUserOutOfEdEHR (clearDemo=true) {
+  async exitFullDemo () {
+    await this.logUserOutOfEdEHR()
+    await this._dispatchDemoStore('demoLogout')
+  }
+  async logUserOutOfEdEHR () {
     StoreHelper.postActionEvent(SYSTEM_ACTION,'logUserOut')
-    EventBus.$emit(USER_LOGOUT_EVENT)
-    const dt = StoreHelper.getDemoToken()
-    if (clearDemo && dt) {
-      await this._dispatchDemoStore('demoLogout')
-    }
     await this._dispatchAssignment('clearAssignment')
     await this._dispatchAuthStore('logOutUser')
     await this._dispatchCourse('clearCourse')
@@ -650,8 +648,7 @@ class StoreHelperWorker {
   async exitToLms () {
     StoreHelper.postActionEvent(SYSTEM_ACTION,'exitToLms')
     const url = StoreHelper.lmsUrl()
-    const clearDemo = false
-    await StoreHelper.logUserOutOfEdEHR(clearDemo)
+    await StoreHelper.logUserOutOfEdEHR()
     window.location = url
   }
 

--- a/client/src/helpers/web-socket-client.js
+++ b/client/src/helpers/web-socket-client.js
@@ -14,12 +14,15 @@ export function setupWebSocket () {
   let baseUrl = StoreHelper.wsUrlGet()
   let client = null
   // When the user logs in try to start the connection
-  EventBus.$on(USER_LOGIN_EVENT, start)
+  EventBus.$on(USER_LOGIN_EVENT, () => {
+    if (details) console.log(PX + 'user logging in so start web socket client')
+    start()
+  })
 
   function start (){
     const token = StoreHelper.getAuthToken()
     if(!token) {
-      if (details) console.log(PX + 'No token so no attempt to connect')
+      if (details) console.log(PX + 'User is not logged in so no attempt to connect')
       return
     }
     let url = baseUrl + '?token=' + token
@@ -33,13 +36,13 @@ export function setupWebSocket () {
           // do nothing. Server is responding to this client's message.
           if (details) console.log(PX + HEARTBEAT)
         } else {
-          if (detailMessages) console.log('socket onmessage', value)
+          if (detailMessages) console.log(PX + 'socket onmessage', value)
           // send the message to another part of the application, for processing
           EventBus.$emit(MESSAGE_FROM_SERVER, value)
         }
       }
       client.onclose = function (event) {
-        if (details) console.log('connection closed', event.code)
+        if (details) console.log(PX + 'connection closed', event.code)
         // release memory
         EventBus.$off(USER_LOGOUT_EVENT)
       }
@@ -67,7 +70,7 @@ export function setupWebSocket () {
       console.error('check while WS is in some unknown state')
     }
   }
-  // try to start on setup. This will likely not work because the user is not likely logged in, but checking doesn't hurt.
+  // try to start on setup. This will try if the user is logged in.
   start()
   // set up to periodically check the connection and reconnect if necessary.
   setInterval(check, CHECK_DELAY)

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -101,7 +101,7 @@ new Vue({
   created: function () {
     initializeStore(store)
 
-    // setupWebSocket()
-    // setupRealTime()
+    setupWebSocket()
+    setupRealTime()
   }
 }).$mount('#app')

--- a/client/src/outside/views/Demo.vue
+++ b/client/src/outside/views/Demo.vue
@@ -3,7 +3,7 @@
     section(v-if="canAccessDemo", class="content")
       div(style="display: flex;")
         h2(class="has-text-centered") {{ demoText.title }}
-        ui-button(@buttonClicked="logout" secondary, style='margin-left: auto;')
+        ui-button(@buttonClicked="fullExit" secondary, style='margin-left: auto;')
           span Exit Full Demo
       div
         div(v-text-to-html="demoText.intro")
@@ -33,7 +33,7 @@
       ui-confirm(
         class="confirmDialog",
         ref="confirmDialog",
-        @confirm="demoLogOut",
+        @confirm="confirmedFullExit",
         save-label="Logout")
 
     div(v-else)
@@ -78,19 +78,12 @@ export default {
       StoreHelper.setDemoPersona(this.persona)
       this.$router.push('demo-course')
     },
-    logout () {
+    fullExit () {
       this.$refs.confirmDialog.showDialog(demoText.logout.title, demoText.logout.body)
     },
-    async demoLogOut () {
-      await StoreHelper.logUserOutOfEdEHR()
+    async confirmedFullExit () {
+      await StoreHelper.exitFullDemo()
       this.$router.push('/')
-    },
-
-  },
-  watch: {
-    $route: function (route) {
-      console.log('Demo page nav. Clear any previous AuthToken whether user came from an LMS or from the demo')
-      StoreHelper.logUserOutOfEdEHR()
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edehr",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edehr",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "authors": [
     {
       "name": "edehr.org",

--- a/server/src/mcr/auth/auth-controller.js
+++ b/server/src/mcr/auth/auth-controller.js
@@ -138,6 +138,8 @@ export default class AuthController {
     if(req.headers.authorization) {
       try {
         const result = this.authUtil.authenticate(req.headers.authorization)
+        const { visitId, secondsRemaining } = result
+        debug('Get auth tkn content for visit: ' + visitId + ' time remaining: ' + secondsRemaining)
         res.status(200).json(result)
       } catch(err) {
         // EXPIRED_TOKEN

--- a/server/src/mcr/common/auth-util.js
+++ b/server/src/mcr/common/auth-util.js
@@ -80,7 +80,7 @@ export default class AuthUtil {
 
   createToken (data, expiry) {
     const options = expiry ?  { expiresIn: expiry } : undefined
-    logAuth.enabled ? logAuth('authController -- createToken', options, data) : debug('authUtils -- createToken')
+    logAuth.enabled ? logAuth('authUtils -- createToken', options, data) : debug('authUtils -- createToken')
     const token = jwt.sign(data, this.tokenSecret, options)
     logAuth('authController -- created this token', this.hashToken(token))
     return token

--- a/server/src/server/server.js
+++ b/server/src/server/server.js
@@ -19,7 +19,7 @@ ehrApp.setup(configuration)
       const appServer = app.listen(serverPort, () => {
         console.log('Server running...', serverPort)
       })
-      //setupWebSocket(appServer, app.authUtil)
+      setupWebSocket(appServer, app.authUtil)
     }
   })
 


### PR DESCRIPTION
Previous design created an event listener per connection and that's a problem because the system has limited event listeners.
So, redesigned to use a single listener for all connections. Decided to make the client code into a class rather than a function to improve separation of concerns.

Introduce new event when user "logs in" and "logs out".  Decided to use the moment the auth header is set/unset to fire this event.
The event is useful to close websocket connections.
