### PR TITLE
EhrOnly, MAR, MedOrder, Checkboxes, CalBool, MedLab, 

### DIFF
--- a/client/src/demos/erin-johns-seed-day2-end.json
+++ b/client/src/demos/erin-johns-seed-day2-end.json
@@ -1,5 +1,5 @@
 {
-  "id": "5d6786b88d19fb14c0994a5f",
+  "id": "65340e6cf5066d61bb6f065b",
   "license": "This work is licensed under a Creative Commons Attribution 4.0 International License. See http://creativecommons.org/licenses/by/4.0/",
   "appType": "EHR",
   "ehrData": {
@@ -7,7 +7,7 @@
       "familyName": "Johns",
       "givenName": "Erin",
       "preferredName": "Erin",
-      "dateOfBirth": "09-SEP-1948",
+      "dateOfBirth": "09-SEP-1945",
       "personAge": "74",
       "gender": "Female",
       "martialStatus": "Widowed",
@@ -20,7 +20,8 @@
       "noAddress": false,
       "phoneNumber": "(778) 555-2947",
       "occupationStudent": "Retired",
-      "phn": "94561234",
+      "phn": "12345678",
+      "mrn": "0003",
       "nextOfKinName": "Thomas Johns",
       "nextOfKinRelationship": "Son",
       "nextOfKinPhone": "604-555-9865",
@@ -48,45 +49,27 @@
     "genitourinary": {
       "table": [
         {
-          "name": "Jason",
-          "day": "0",
-          "time": "19:30",
           "none": true,
           "lastVoidedDay": "0",
-          "lastVoidedTime": "16:00",
+          "lastVoidedTime": "1600",
           "colour": "Pale yellow",
           "consistency": "Clear",
           "diaper": "No",
           "foley": "No",
-          "profession": "RN",
           "pelvicPain": "No",
           "pregnant": "No",
           "gravida": "5",
           "para": "4",
           "livingChildren": "4",
-          "createdDate": "2019-05-30T22:40:29-07:00"
+          "createdDate": "2019-05-30T22:40:29-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "genitourinary.table.0"
         }
       ]
     },
-    "medicationOrders": {
-      "table": [
-        {
-          "name": "Dr. Singh",
-          "profession": "Physician",
-          "day": 0,
-          "time": "1015",
-          "medication": "spiriva respimat",
-          "dose": "5 mcg",
-          "route": "Inhalation",
-          "administration": "once",
-          "instructions": "5 mcg (2 actuations; 2.5 mcg/actuation) inhaled PO qDay",
-          "reason": "PO",
-          "notes": "reduction of COPD exacerbations",
-          "createdDate": "2022-12-06T11:45:34-08:00"
-        }
-      ]
-    },
-
     "allergies": {
       "checkbox": "TRUE"
     },
@@ -96,7 +79,8 @@
           "physician": "Dr. Henley",
           "procedure": "Cesarean section",
           "timeSince": "48 years",
-          "createdDate": "2019-05-30T09:36:55-07:00"
+          "createdDate": "2019-05-30T09:36:55-07:00",
+          "pastSurgery_id": "surgical.pastSurgery.0"
         }
       ],
       "previous": []
@@ -106,67 +90,80 @@
         {
           "name": "Dr. Singh",
           "profession": "Physician",
-          "createdDate": "2019-05-30T09:39:52-07:00"
+          "createdDate": "2019-05-30T09:39:52-07:00",
+          "teams_id": "careTeam.teams.0"
         },
         {
           "name": "Jackie",
           "profession": "RN",
-          "createdDate": "2019-05-30T09:40:00-07:00"
+          "createdDate": "2019-05-30T09:40:00-07:00",
+          "teams_id": "careTeam.teams.1"
         },
         {
           "name": "Jason",
           "profession": "RN",
-          "createdDate": "2019-05-30T09:40:07-07:00"
+          "createdDate": "2019-05-30T09:40:07-07:00",
+          "teams_id": "careTeam.teams.2"
         },
         {
           "name": "Alexa",
           "profession": "Med lab technician",
-          "createdDate": "2019-05-30T09:40:19-07:00"
+          "createdDate": "2019-05-30T09:40:19-07:00",
+          "teams_id": "careTeam.teams.3"
         },
         {
           "name": "Gurpreet",
           "profession": "Med radiographer",
-          "createdDate": "2019-05-30T09:40:39-07:00"
+          "createdDate": "2019-05-30T09:40:39-07:00",
+          "teams_id": "careTeam.teams.4"
         },
         {
           "name": "Matt",
           "profession": "Respiratory therapist",
-          "createdDate": "2019-05-30T09:40:54-07:00"
+          "createdDate": "2019-05-30T09:40:54-07:00",
+          "teams_id": "careTeam.teams.5"
         },
         {
           "name": "Dr. Notley",
           "profession": "Physician",
-          "createdDate": "2019-05-30T09:41:09-07:00"
+          "createdDate": "2019-05-30T09:41:09-07:00",
+          "teams_id": "careTeam.teams.6"
         },
         {
           "name": "Serge",
           "profession": "Med radiographer",
-          "createdDate": "2019-05-30T09:41:23-07:00"
+          "createdDate": "2019-05-30T09:41:23-07:00",
+          "teams_id": "careTeam.teams.7"
         },
         {
           "name": "Trache",
           "profession": "RN",
-          "createdDate": "2019-05-30T09:41:37-07:00"
+          "createdDate": "2019-05-30T09:41:37-07:00",
+          "teams_id": "careTeam.teams.8"
         },
         {
           "name": "Dr. Hunicutt",
           "profession": "Physician",
-          "createdDate": "2019-05-30T09:41:50-07:00"
+          "createdDate": "2019-05-30T09:41:50-07:00",
+          "teams_id": "careTeam.teams.9"
         },
         {
           "name": "Jim",
           "profession": "RN",
-          "createdDate": "2019-05-30T09:41:59-07:00"
+          "createdDate": "2019-05-30T09:41:59-07:00",
+          "teams_id": "careTeam.teams.10"
         },
         {
           "name": "Gladys",
           "profession": "physiotherapy student",
-          "createdDate": "2019-05-30T09:42:14-07:00"
+          "createdDate": "2019-05-30T09:42:14-07:00",
+          "teams_id": "careTeam.teams.11"
         },
         {
           "name": "Herman",
           "profession": "Respiratory therapist",
-          "createdDate": "2019-05-30T09:42:39-07:00"
+          "createdDate": "2019-05-30T09:42:39-07:00",
+          "teams_id": "careTeam.teams.12"
         }
       ]
     },
@@ -178,19 +175,16 @@
           "site": "Clinic",
           "reasonForVisit": "Shortness of breath x 24 hours",
           "diagnosis": "COPD",
-          "createdDate": "2019-05-30T09:43:19-07:00"
+          "createdDate": "2019-05-30T09:43:19-07:00",
+          "outpatientAppointments_id": "pastAppointments.outpatientAppointments.0"
         }
       ]
     },
     "vitals": {
       "table": [
         {
-          "name": "Jason",
-          "profession": "RN",
           "entryDay": "1",
           "entryTime": "18:00",
-          "day": "1",
-          "time": "18:00",
           "temperature": "36.5",
           "source": "Axilla",
           "strength": "Peripheral",
@@ -202,15 +196,16 @@
           "respirationRate": "28",
           "oxygenSaturation": "85%",
           "oxygenMode": "Optiflow",
-          "createdDate": "2019-05-30T10:18:43-07:00"
+          "createdDate": "2019-05-30T10:18:43-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "1",
+          "table_time": "1800",
+          "table_id": "vitals.table.0"
         },
         {
-          "name": "Jason",
-          "profession": "RN",
           "entryDay": "1",
           "entryTime": "07:00",
-          "day": "1",
-          "time": "07:00",
           "temperature": "36.5",
           "source": "Axilla",
           "strength": "Peripheral",
@@ -223,15 +218,16 @@
           "oxygenSaturation": "90%",
           "oxygenMode": "Nasal prongs",
           "flowRate": "5",
-          "createdDate": "2019-05-30T10:04:20-07:00"
+          "createdDate": "2019-05-30T10:04:20-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "1",
+          "table_time": "0700",
+          "table_id": "vitals.table.1"
         },
         {
-          "name": "Jason",
-          "profession": "RN",
           "entryDay": "1",
           "entryTime": "02:00",
-          "day": "1",
-          "time": "02:00",
           "temperature": "36.5",
           "source": "Axilla",
           "strength": "Peripheral",
@@ -244,15 +240,16 @@
           "oxygenSaturation": "90%",
           "oxygenMode": "Nasal prongs",
           "createdDate": "2019-05-30T09:57:51-07:00",
-          "flowRate": "2L"
+          "flowRate": "2L",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "1",
+          "table_time": "0200",
+          "table_id": "vitals.table.2"
         },
         {
-          "name": "Jason",
-          "profession": "RN",
           "entryDay": "0",
           "entryTime": "20:00",
-          "day": "0",
-          "time": "20:00",
           "temperature": "36.4",
           "source": "Axilla",
           "strength": "Peripheral",
@@ -264,15 +261,16 @@
           "respirationRate": "26",
           "oxygenSaturation": "84%",
           "oxygenMode": "Room air",
-          "createdDate": "2019-05-30T09:56:14-07:00"
+          "createdDate": "2019-05-30T09:56:14-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "2000",
+          "table_id": "vitals.table.3"
         },
         {
-          "name": "Jason",
-          "profession": "RN",
           "entryDay": "0",
           "entryTime": "18:00",
-          "day": "0",
-          "time": "18:00",
           "temperature": "36.5",
           "source": "Axilla",
           "strength": "Peripheral",
@@ -284,17 +282,18 @@
           "respirationRate": "28",
           "oxygenSaturation": "85%",
           "oxygenMode": "Room air",
-          "createdDate": "2019-05-30T09:53:32-07:00"
+          "createdDate": "2019-05-30T09:53:32-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1800",
+          "table_id": "vitals.table.4"
         }
       ]
     },
     "neurological": {
       "table": [
         {
-          "name": "Jason",
-          "profession": "RN",
-          "day": "0",
-          "time": "19:30",
           "alert": true,
           "oriented": true,
           "eyeOpening": "4 = Spontaneous",
@@ -323,7 +322,12 @@
           "dysarthria": "0 = Normal",
           "extinctionAndInattention": "0 = No abnormality",
           "strokeAssessmentCalculation": 0,
-          "createdDate": "2019-05-30T21:50:42-07:00"
+          "createdDate": "2019-05-30T21:50:42-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "neurological.table.0"
         }
       ]
     },
@@ -331,11 +335,12 @@
       "table": [
         {
           "location": "Emergency room",
-          "createdDate": "2019-05-30T23:21:10-07:00"
+          "createdDate": "2019-05-30T23:21:10-07:00",
+          "table_id": "visit.table.0"
         }
       ],
-      "admissionDay": "0",
-      "admissionTime": "06:00",
+      "admissionDay": "Day 0",
+      "admissionTime": "0600",
       "consentForTreatment": "TRUE",
       "consentForBlood": "TRUE",
       "diagnosis": "COPD\nShortness of breath\nDizzy",
@@ -344,10 +349,6 @@
     "respiratory": {
       "table": [
         {
-          "name": "Jason",
-          "profession": "RN",
-          "day": "0",
-          "time": "19:30",
           "patent": true,
           "lul": "Normal",
           "rul": "Normal",
@@ -357,17 +358,18 @@
           "respiratoryRhythm": "Regular",
           "respiratoryDepth": "Shallow",
           "cough": "No",
-          "createdDate": "2019-05-30T22:32:42-07:00"
+          "createdDate": "2019-05-30T22:32:42-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "respiratory.table.0"
         }
       ]
     },
     "cardiovascular": {
       "table": [
         {
-          "name": "Jason",
-          "profession": "RN",
-          "day": "0",
-          "time": "19:30",
           "pulse": "Regular",
           "skinAppearance": "Normal",
           "capRefillRightHand": "Normal < 3 seconds",
@@ -386,17 +388,18 @@
           "nailBedColourLeftHand": "Pink",
           "nailBedColourRightFoot": "Pink",
           "nailBedColourLeftFoot": "Pink",
-          "createdDate": "2019-05-30T22:37:16-07:00"
+          "createdDate": "2019-05-30T22:37:16-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "cardiovascular.table.0"
         }
       ]
     },
     "gastrointestinal": {
       "table": [
         {
-          "name": "Jason",
-          "profession": "RN",
-          "day": "0",
-          "time": "19:30",
           "soft": true,
           "pain": "No",
           "eating": "Regular",
@@ -407,17 +410,18 @@
           "bsRUQ": true,
           "bsLLQ": true,
           "bsRLQ": true,
-          "createdDate": "2019-05-30T22:38:55-07:00"
+          "createdDate": "2019-05-30T22:38:55-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "gastrointestinal.table.0"
         }
       ]
     },
     "musculoskeletal": {
       "table": [
         {
-          "name": "Jason",
-          "profession": "RN",
-          "day": "0",
-          "time": "19:30",
           "swelling": "Absent",
           "pain": "Absent",
           "deformity": "Absent",
@@ -427,30 +431,32 @@
           "colour": "Flesh",
           "temp": "Warm",
           "useOfAmbulatoryAid": "No",
-          "createdDate": "2019-05-30T22:41:28-07:00"
+          "createdDate": "2019-05-30T22:41:28-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "musculoskeletal.table.0"
         }
       ]
     },
     "pain": {
       "table": [
         {
-          "name": "Jason",
-          "day": "0",
-          "time": "19:30",
           "painScale": "0",
           "respiratoryRate": "28",
-          "profession": "RN",
-          "createdDate": "2019-05-30T22:42:51-07:00"
+          "createdDate": "2019-05-30T22:42:51-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "pain.table.0"
         }
       ]
     },
     "biopsychosocial": {
       "table": [
         {
-          "name": "Jason",
-          "profession": "RN",
-          "day": "0",
-          "time": "19:30",
           "domesticViolence": "No",
           "requestContact": "No",
           "hygieneGrooming": "Good",
@@ -461,144 +467,305 @@
           "speech": "Clear and coherent",
           "supportPerson": "Thomas (Son)",
           "securityPolicePresent": "No",
-          "createdDate": "2019-05-30T22:48:02-07:00"
+          "createdDate": "2019-05-30T22:48:02-07:00",
+          "table_name": "Jason",
+          "table_profession": "RN",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "biopsychosocial.table.0"
         }
       ]
     },
     "nonmedOrders": {
       "table": [
         {
-          "name": "Dr. Singh",
-          "profession": "Physician",
-          "day": "0",
-          "time": "20:00",
           "order": "Chest xray",
           "orderedBy": "Dr. Singh",
           "dayOfReferral": "0",
           "startDay": "0",
           "startTime": "20:00",
           "status": "Ordered",
-          "createdDate": "2019-05-30T22:50:10-07:00"
+          "createdDate": "2019-05-30T22:50:10-07:00",
+          "table_name": "Dr. Singh",
+          "table_profession": "Physician",
+          "table_day": "0",
+          "table_time": "2000",
+          "table_id": "nonmedOrders.table.0"
         },
         {
-          "name": "Dr. Singh",
-          "profession": "Physician",
-          "day": "0",
-          "time": "20:00",
           "order": "ABG",
           "orderedBy": "Dr. Singh",
           "dayOfReferral": "0",
           "startDay": "0",
           "startTime": "20:00",
           "status": "Ordered",
-          "createdDate": "2019-05-30T22:50:45-07:00"
+          "createdDate": "2019-05-30T22:50:45-07:00",
+          "table_name": "Dr. Singh",
+          "table_profession": "Physician",
+          "table_day": "0",
+          "table_time": "2000",
+          "table_id": "nonmedOrders.table.1"
         },
         {
-          "name": "Dr. Singh",
-          "profession": "Physician",
-          "day": "0",
-          "time": "20:00",
-          "order": "CBC, electrolytes, BUN, creatine",
+          "order": "CBC, electrolytes, BUN, creatinine",
           "orderedBy": "Dr. Singh",
           "dayOfReferral": "0",
           "startDay": "0",
           "startTime": "20:00",
           "status": "Ordered",
-          "createdDate": "2019-05-30T22:51:21-07:00"
+          "createdDate": "2019-05-30T22:51:21-07:00",
+          "table_name": "Dr. Singh",
+          "table_profession": "Physician",
+          "table_day": "0",
+          "table_time": "2000",
+          "table_id": "nonmedOrders.table.2"
         },
         {
-          "name": "Dr. Singh",
-          "profession": "Physician",
-          "day": "0",
-          "time": "20:00",
           "order": "Spirometry",
           "orderedBy": "Dr. Singh",
           "dayOfReferral": "0",
           "startDay": "0",
           "startTime": "20:00",
           "status": "Ordered",
-          "createdDate": "2019-05-30T22:51:50-07:00"
+          "createdDate": "2019-05-30T22:51:50-07:00",
+          "table_name": "Dr. Singh",
+          "table_profession": "Physician",
+          "table_day": "0",
+          "table_time": "2000",
+          "table_id": "nonmedOrders.table.3"
         }
       ]
     },
     "referrals": {
       "table": [
         {
-          "name": "Dr. Singh",
-          "profession": "Physician",
-          "day": "0",
-          "time": "19:30",
           "referralName": "Matt",
           "referralProfession": "Resp therapy",
           "appointmentDate": "One week",
-          "appointmentTime": "20:00",
+          "appointmentTime": "2000",
           "status": "Active",
-          "createdDate": "2019-05-30T22:52:30-07:00"
+          "createdDate": "2019-05-30T22:52:30-07:00",
+          "table_name": "Dr. Singh",
+          "table_profession": "Physician",
+          "table_day": "0",
+          "table_time": "1930",
+          "table_id": "referrals.table.0"
         }
       ]
-    },
-    "dischargeSummary": {
-      "clinicalSummary": "Patient arrived with chronic COPD in acute form\nPreviously diagnosed with hypertension\nDeveloped bilateral gram positive cocci pneumonia\nTreated with intravenous antibiotics and responded well",
-      "dischargeDay": "Day 6",
-      "dischargeTime": "08:00",
-      "dischargedTo": "Home"
     },
     "billing": {
       "msp": "MSP",
       "thirdParty": false,
       "federal": false
     },
-    "diagnosticCodes": {
-      "table": [
+    "medicationOrders": {
+      "lastUpdate": "2023-05-21T22:07:22-07:00",
+      "medicationOrdersTable": [
         {
-          "name": "Pat",
-          "day": "6",
-          "time": "10:15",
-          "condition": "COPD",
-          "code": "J44.9",
-          "type": "M",
-          "createdDate": "2019-05-30T23:11:12-07:00"
+          "medicationOrdersTable_name": "Dr Notley",
+          "medicationOrdersTable_profession": "Physician",
+          "medicationOrdersTable_day": "0",
+          "medicationOrdersTable_time": "1400",
+          "med_timing": "od",
+          "med_route": "inha",
+          "med_reason": "to alleviate bronchospasm and improve airflow",
+          "med_medication": "Tiotropium bromide (Spiriva) inhalation capsules, 18 mcg",
+          "med_dose": "1",
+          "createdDate": "2023-05-21T21:52:33-07:00",
+          "medicationOrdersTable_id": "medicationOrders.medicationOrdersTable.0"
         },
         {
-          "name": "Pat",
-          "day": "6",
-          "time": "10:15",
-          "condition": "COPD",
-          "code": "Z86.42",
-          "type": "3",
-          "createdDate": "2019-05-30T23:11:44-07:00"
+          "medicationOrdersTable_name": "Dr Notley",
+          "medicationOrdersTable_profession": "Physician",
+          "medicationOrdersTable_day": "0",
+          "medicationOrdersTable_time": "1400",
+          "med_timing": "prn",
+          "med_route": "inha",
+          "med_medication": "Salbutamol (Ventolin) inhaler, 100 mcg:",
+          "med_dose": "2 puffs",
+          "med_scheduled": "Q6H",
+          "med_time1": "0200",
+          "med_time2": "0600",
+          "med_time3": "1200",
+          "med_time4": "1800",
+          "med_time5": "2200",
+          "med_instructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "createdDate": "2023-05-21T21:54:12-07:00",
+          "medicationOrdersTable_id": "medicationOrders.medicationOrdersTable.1"
         },
         {
-          "name": "Pat",
-          "day": "6",
-          "time": "10:15",
-          "condition": "COPD",
-          "code": "I10",
-          "type": "3",
-          "createdDate": "2019-05-30T23:12:04-07:00"
+          "medicationOrdersTable_name": "Dr Notley",
+          "medicationOrdersTable_profession": "Physician",
+          "medicationOrdersTable_day": "0",
+          "medicationOrdersTable_time": "1400",
+          "med_timing": "od",
+          "med_route": "oral",
+          "med_medication": "Amlodipine besylate",
+          "med_dose": "5 mg",
+          "med_instructions": "Take one tablet orally with or without food.\nIt is important to take the medication at the same time each day to maintain consistent blood pressure control.\nMonitor blood pressure regularly to assess the response to treatment and ensure blood pressure remains within target ranges.\nAdvise the patient to adhere to a healthy lifestyle, including a balanced diet, regular exercise, weight management, and reduction in sodium intake.\nEducate the patient about potential side effects of the medication and the importance of reporting any adverse effects or concerns promptly.",
+          "createdDate": "2023-05-21T22:07:21-07:00",
+          "medicationOrdersTable_id": "medicationOrders.medicationOrdersTable.2"
         }
       ]
     },
-    "interventionCodes": {
-      "table": [
+    "medAdminRec": {
+      "lastUpdate": "2023-05-21T22:28:30-07:00",
+      "marTable": [
         {
-          "name": "Pat",
-          "day": "6",
-          "time": "10:15",
-          "intervention": "3.GY.10.VA",
-          "createdDate": "2019-05-30T23:12:40-07:00"
+          "marTable_name": "Dorothea",
+          "marTable_profession": "RN",
+          "marTable_day": "0",
+          "marTable_time": "1800",
+          "med_order_embedded": "medicationOrders.medicationOrdersTable.1",
+          "mo_medOrder": "Salbutamol (Ventolin) inhaler, 100 mcg: 2 puffs inha Q6H",
+          "mo_medInstructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "mo_schedDay": 0,
+          "mo_schedTime": "1800",
+          "mo_id": "medicationOrders.medicationOrdersTable.1",
+          "mar_status": "Administered",
+          "mar_dose": "2 puffs",
+          "medicationOrdersTable_name": "Dr Notley",
+          "medicationOrdersTable_profession": "Physician",
+          "medicationOrdersTable_day": "0",
+          "medicationOrdersTable_time": "1400",
+          "med_timing": "prn",
+          "med_route": "inha",
+          "med_medication": "Salbutamol (Ventolin) inhaler, 100 mcg:",
+          "med_dose": "2 puffs",
+          "med_scheduled": "Q6H",
+          "med_time1": "0200",
+          "med_time2": "0600",
+          "med_time3": "1200",
+          "med_time4": "1800",
+          "med_time5": "2200",
+          "med_instructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "createdDate": "2023-05-21T22:14:38-07:00",
+          "marTable_id": "medAdminRec.marTable.0"
         },
         {
-          "name": "Pat",
-          "day": "6",
-          "time": "10:15",
-          "intervention": "2.GZ.21.EA",
-          "createdDate": "2019-05-30T23:12:59-07:00"
+          "marTable_name": "Dorothea",
+          "marTable_profession": "RN",
+          "marTable_day": "0",
+          "marTable_time": "2200",
+          "med_order_embedded": "medicationOrders.medicationOrdersTable.1",
+          "mo_medOrder": "Salbutamol (Ventolin) inhaler, 100 mcg: 2 puffs inha Q6H",
+          "mo_medInstructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "mo_schedDay": 0,
+          "mo_schedTime": "2200",
+          "mo_id": "medicationOrders.medicationOrdersTable.1",
+          "mar_status": "Administered",
+          "mar_dose": "2 puffs",
+          "medicationOrdersTable_name": "Dr Notley",
+          "medicationOrdersTable_profession": "Physician",
+          "medicationOrdersTable_day": "0",
+          "medicationOrdersTable_time": "1400",
+          "med_timing": "prn",
+          "med_route": "inha",
+          "med_medication": "Salbutamol (Ventolin) inhaler, 100 mcg:",
+          "med_dose": "2 puffs",
+          "med_scheduled": "Q6H",
+          "med_time1": "0200",
+          "med_time2": "0600",
+          "med_time3": "1200",
+          "med_time4": "1800",
+          "med_time5": "2200",
+          "med_instructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "createdDate": "2023-05-21T22:26:20-07:00",
+          "marTable_id": "medAdminRec.marTable.1"
+        },
+        {
+          "marTable_name": "Dorothea",
+          "marTable_profession": "RN",
+          "marTable_day": "0",
+          "marTable_time": "1800",
+          "med_order_embedded": "medicationOrders.medicationOrdersTable.0",
+          "mo_medOrder": "Tiotropium bromide (Spiriva) inhalation capsules, 18 mcg 1 inha ",
+          "mo_id": "medicationOrders.medicationOrdersTable.0",
+          "mar_status": "Administered",
+          "mar_dose": "1 puff",
+          "med_timing": "od",
+          "med_reason": "to alleviate bronchospasm and improve airflow",
+          "med_medication": "Tiotropium bromide (Spiriva) inhalation capsules, 18 mcg",
+          "med_dose": "1",
+          "createdDate": "2023-05-21T22:26:51-07:00",
+          "marTable_id": "medAdminRec.marTable.2"
+        },
+        {
+          "marTable_name": "Dorothea",
+          "marTable_profession": "RN",
+          "marTable_day": 1,
+          "marTable_time": "0800",
+          "med_order_embedded": "medicationOrders.medicationOrdersTable.2",
+          "mo_medOrder": "Amlodipine besylate 5 mg oral ",
+          "mo_medInstructions": "Take one tablet orally with or without food.\nIt is important to take the medication at the same time each day to maintain consistent blood pressure control.\nMonitor blood pressure regularly to assess the response to treatment and ensure blood pressure remains within target ranges.\nAdvise the patient to adhere to a healthy lifestyle, including a balanced diet, regular exercise, weight management, and reduction in sodium intake.\nEducate the patient about potential side effects of the medication and the importance of reporting any adverse effects or concerns promptly.",
+          "mo_id": "medicationOrders.medicationOrdersTable.2",
+          "mar_status": "Administered",
+          "mar_dose": "5 mg",
+          "med_route": "oral",
+          "med_medication": "Amlodipine besylate",
+          "med_dose": "5 mg",
+          "med_instructions": "Take one tablet orally with or without food.\nIt is important to take the medication at the same time each day to maintain consistent blood pressure control.\nMonitor blood pressure regularly to assess the response to treatment and ensure blood pressure remains within target ranges.\nAdvise the patient to adhere to a healthy lifestyle, including a balanced diet, regular exercise, weight management, and reduction in sodium intake.\nEducate the patient about potential side effects of the medication and the importance of reporting any adverse effects or concerns promptly.",
+          "createdDate": "2023-05-21T22:27:26-07:00",
+          "marTable_id": "medAdminRec.marTable.3"
+        },
+        {
+          "marTable_name": "Dorothea",
+          "marTable_profession": "rN",
+          "marTable_day": "1",
+          "marTable_time": "0200",
+          "med_order_embedded": "medicationOrders.medicationOrdersTable.1",
+          "mo_medOrder": "Salbutamol (Ventolin) inhaler, 100 mcg: 2 puffs inha Q6H",
+          "mo_medInstructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "mo_schedDay": 1,
+          "mo_schedTime": "0200",
+          "mo_id": "medicationOrders.medicationOrdersTable.1",
+          "mar_status": "Administered",
+          "mar_dose": "2 puffs",
+          "med_timing": "prn",
+          "med_route": "inha",
+          "med_medication": "Salbutamol (Ventolin) inhaler, 100 mcg:",
+          "med_dose": "2 puffs",
+          "med_scheduled": "Q6H",
+          "med_time1": "0200",
+          "med_time2": "0600",
+          "med_time3": "1200",
+          "med_time4": "1800",
+          "med_time5": "2200",
+          "med_instructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "createdDate": "2023-05-21T22:28:09-07:00",
+          "marTable_id": "medAdminRec.marTable.4"
+        },
+        {
+          "marTable_name": "Dorothea",
+          "marTable_profession": "RN",
+          "marTable_day": 1,
+          "marTable_time": "0600",
+          "med_order_embedded": "medicationOrders.medicationOrdersTable.1",
+          "mo_medOrder": "Salbutamol (Ventolin) inhaler, 100 mcg: 2 puffs inha Q6H",
+          "mo_medInstructions": "2 puffs as needed every 4-6 hours for rescue relief of acute symptoms.",
+          "mo_schedDay": 1,
+          "mo_schedTime": "0600",
+          "mo_id": "medicationOrders.medicationOrdersTable.1",
+          "mar_status": "Administered",
+          "mar_dose": "2 puffs",
+          "createdDate": "2023-05-21T22:28:30-07:00",
+          "marTable_id": "medAdminRec.marTable.5"
         }
       ]
+    },
+    "meta": {
+      "simTime": {
+        "visitDay": 1,
+        "visitTime": "1800"
+      },
+      "ehrVersion": "ev2.4.0"
     }
   },
-  "description": "This EHR Seed is based on a case from 'Health Case Studies - Toward Closing the Healthcare Communication Gap'. This EHR seed reflects a point during a patient's Day 2 stay in the hospital ",
-  "name": "Erin Johns Day 2",
-  "version": "1.0"
+  "description": "\"Health Case Studies - Toward Closing the Healthcare Communication Gap\" by:  Glynda Rees, Rob Kruger, Janet Morrison.  See: pages 31 up to 62 in Case Study #2 in https://pressbooks.bccampus.ca/healthcasestudies/ \n In this case the patient has chronic obstructive pulmonary disease (COPD) that is exacerbated due to community acquired pneumonia.  The patient in this case study has a complicated health history. This simulation follows the case study up to 18:00 of Day 1.  The case study continues through to discharge on Day 4. ",
+  "name": "Erin Johns - CS#2",
+  "tagList": [
+    "COPD"
+  ],
+  "version": "1",
+  "fileName": "erinJohnsCs#2_1_21 Oct 2023.json"
 }

--- a/client/src/ehr-definitions/ehr-page-defs.js
+++ b/client/src/ehr-definitions/ehr-page-defs.js
@@ -12723,6 +12723,14 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
+        'elementKey': 'med_second_signature',
+        'formIndex': '2',
+        'inputType': 'checkbox',
+        'label': 'Second signature require',
+        'tableColumn': '8',
+        'fqn': 'medicationOrders.med_second_signature'
+      },
+      {
         'elementKey': 'med_scheduled',
         'formIndex': '2',
         'inputType': 'select',
@@ -12765,7 +12773,7 @@ const DEFS = {
             'text': 'Q1H'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medicationOrders.med_scheduled'
       },
       {
@@ -12773,7 +12781,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Max dosage',
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medicationOrders.med_prnMaxDosage'
       },
       {
@@ -12782,7 +12790,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 1',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time1'
       },
@@ -12792,7 +12800,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 2',
-        'tableColumn': '11',
+        'tableColumn': '12',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time2'
       },
@@ -12802,7 +12810,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 3',
-        'tableColumn': '12',
+        'tableColumn': '13',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time3'
       },
@@ -12812,7 +12820,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 4',
-        'tableColumn': '13',
+        'tableColumn': '14',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time4'
       },
@@ -12822,7 +12830,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 5',
-        'tableColumn': '14',
+        'tableColumn': '15',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time5'
       },
@@ -12832,7 +12840,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 6',
-        'tableColumn': '15',
+        'tableColumn': '16',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time6'
       },
@@ -12841,7 +12849,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Continuous description',
-        'tableColumn': '16',
+        'tableColumn': '17',
         'fqn': 'medicationOrders.med_continuous_description'
       },
       {
@@ -12850,7 +12858,7 @@ const DEFS = {
         'inputType': 'textarea',
         'label': 'Instructions',
         'suffix': 'medAdminRec',
-        'tableColumn': '17',
+        'tableColumn': '18',
         'tableLabel': 'Instructions',
         'fqn': 'medicationOrders.med_instructions',
         'suffixText': '<p>medAdminRec</p>',
@@ -13206,60 +13214,66 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_scheduled'
+              'med_second_signature'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'med_prnMaxDosage'
+              'med_scheduled'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
-              'med_time1'
+              'med_prnMaxDosage'
             ]
           },
           {
             'ehr_list_index': '11',
             'items': [
-              'med_time2'
+              'med_time1'
             ]
           },
           {
             'ehr_list_index': '12',
             'items': [
-              'med_time3'
+              'med_time2'
             ]
           },
           {
             'ehr_list_index': '13',
             'items': [
-              'med_time4'
+              'med_time3'
             ]
           },
           {
             'ehr_list_index': '14',
             'items': [
-              'med_time5'
+              'med_time4'
             ]
           },
           {
             'ehr_list_index': '15',
             'items': [
-              'med_time6'
+              'med_time5'
             ]
           },
           {
             'ehr_list_index': '16',
+            'items': [
+              'med_time6'
+            ]
+          },
+          {
+            'ehr_list_index': '17',
             'items': [
               'med_continuous_description'
             ]
           },
           {
             'label': 'Instructions',
-            'ehr_list_index': '17',
+            'ehr_list_index': '18',
             'items': [
               'med_instructions'
             ]
@@ -13307,7 +13321,8 @@ const DEFS = {
               'gIndex': '4',
               'gChildren': [
                 'med_medication',
-                'med_dose'
+                'med_dose',
+                'med_second_signature'
               ]
             },
             {
@@ -13371,6 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
+            'med_second_signature': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13400,6 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
+          'med_second_signature',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13676,7 +13693,6 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'select',
         'label': 'Status',
-        'mandatory': true,
         'options': [
           {
             'key': 'Administered',
@@ -13703,17 +13719,127 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'mandatory': true,
         'tableColumn': '7',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
+        'elementKey': 'mar_route',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Route',
+        'options': [
+          {
+            'key': 'oral',
+            'text': 'Oral'
+          },
+          {
+            'key': 'bucc',
+            'text': 'Buccal'
+          },
+          {
+            'key': 'cuta',
+            'text': 'Cutaneous'
+          },
+          {
+            'key': 'impl',
+            'text': 'Implant'
+          },
+          {
+            'key': 'inha',
+            'text': 'Inhalation'
+          },
+          {
+            'key': 'inje',
+            'text': 'Injection'
+          },
+          {
+            'key': 'intra',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'nasa',
+            'text': 'Nasal'
+          },
+          {
+            'key': 'nebu',
+            'text': 'Nebulization'
+          },
+          {
+            'key': 'ocul',
+            'text': 'Ocular'
+          },
+          {
+            'key': 'otic',
+            'text': 'Otic'
+          },
+          {
+            'key': 'rect',
+            'text': 'Rectal'
+          },
+          {
+            'key': 'subl',
+            'text': 'Sublingual'
+          },
+          {
+            'key': 'tran',
+            'text': 'Transdermal'
+          },
+          {
+            'key': 'vagi',
+            'text': 'Vaginal'
+          }
+        ],
+        'tableColumn': '8',
+        'fqn': 'medAdminRec.mar_route'
+      },
+      {
+        'elementKey': 'mar_injectionLocation',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Injection location',
+        'options': [
+          {
+            'key': 'arterial',
+            'text': 'Arterial'
+          },
+          {
+            'key': 'epidural',
+            'text': 'Epidural'
+          },
+          {
+            'key': 'intramuscular',
+            'text': 'Intramuscular'
+          },
+          {
+            'key': 'intraosseous',
+            'text': 'Intraosseous'
+          },
+          {
+            'key': 'intraperitoneal',
+            'text': 'Intraperitoneal'
+          },
+          {
+            'key': 'intrathecal',
+            'text': 'Intrathecal'
+          },
+          {
+            'key': 'intravenous',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'subcutaneous',
+            'text': 'Subcutaneous'
+          }
+        ],
+        'tableColumn': '9',
+        'fqn': 'medAdminRec.mar_injectionLocation'
+      },
+      {
         'elementKey': 'mar_comments',
         'formIndex': '2',
-        'formCss': 'grid-span-3-columns',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '8',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_comments'
       }
     ],
@@ -13914,6 +14040,18 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
+              'mar_route'
+            ]
+          },
+          {
+            'ehr_list_index': '9',
+            'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '10',
+            'items': [
               'mar_comments'
             ]
           }
@@ -13967,6 +14105,23 @@ const DEFS = {
               'gChildren': [
                 'mar_status',
                 'mar_dose',
+                'mar_route'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_inje',
+              'dependentOn': 'visble:mar_route=inje,intra',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '5',
+              'gChildren': [
+                'mar_injectionLocation'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_notes',
+              'formCss': 'grid-left-to-right-1',
+              'gIndex': '6',
+              'gChildren': [
                 'mar_comments'
               ]
             }
@@ -13985,6 +14140,8 @@ const DEFS = {
             'mo_id': '',
             'mar_status': '',
             'mar_dose': '',
+            'mar_route': '',
+            'mar_injectionLocation': '',
             'mar_comments': ''
           }
         },
@@ -14000,6 +14157,8 @@ const DEFS = {
           'mo_schedTime',
           'mar_status',
           'mar_dose',
+          'mar_route',
+          'mar_injectionLocation',
           'mar_comments'
         ],
         'hasRecHeader': true
@@ -14358,7 +14517,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group371',
+              'elementKey': 'ehr_group370',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14369,7 +14528,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group372',
+              'elementKey': 'ehr_group371',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -14578,7 +14737,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group373',
+              'elementKey': 'ehr_group372',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14589,7 +14748,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group374',
+              'elementKey': 'ehr_group373',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -14752,7 +14911,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group377',
+              'elementKey': 'ehr_group376',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14763,7 +14922,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group378',
+              'elementKey': 'ehr_group377',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -15986,7 +16145,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group383',
+              'elementKey': 'ehr_group382',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -15997,7 +16156,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group384',
+              'elementKey': 'ehr_group383',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -16130,7 +16289,7 @@ const DEFS = {
           'formKey': 'labResultHematology',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group385',
+              'elementKey': 'ehr_group384',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16141,7 +16300,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group386',
+              'elementKey': 'ehr_group385',
               'label': 'Hematology',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16155,7 +16314,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group387',
+              'elementKey': 'ehr_group386',
               'label': 'WBC Types',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16271,7 +16430,7 @@ const DEFS = {
           'formKey': 'labResultCoagulation',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group388',
+              'elementKey': 'ehr_group387',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16282,7 +16441,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group389',
+              'elementKey': 'ehr_group388',
               'label': 'Coagulation',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16531,7 +16690,7 @@ const DEFS = {
           'formKey': 'labResultGeneral',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group390',
+              'elementKey': 'ehr_group389',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16542,7 +16701,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group391',
+              'elementKey': 'ehr_group390',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16561,7 +16720,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group392',
+              'elementKey': 'ehr_group391',
               'label': 'Renal Profile',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16572,7 +16731,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group393',
+              'elementKey': 'ehr_group392',
               'label': 'Liver function',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -16588,7 +16747,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group394',
+              'elementKey': 'ehr_group393',
               'label': 'Blood gas tests',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '5',
@@ -16601,7 +16760,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group395',
+              'elementKey': 'ehr_group394',
               'label': 'Group and screen',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '6',
@@ -16739,7 +16898,7 @@ const DEFS = {
           'formKey': 'troponinTable',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group396',
+              'elementKey': 'ehr_group395',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16750,7 +16909,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group397',
+              'elementKey': 'ehr_group396',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -16975,7 +17134,7 @@ const DEFS = {
           'formKey': 'labResultUrine',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group398',
+              'elementKey': 'ehr_group397',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16986,7 +17145,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group399',
+              'elementKey': 'ehr_group398',
               'label': 'General',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16998,7 +17157,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group400',
+              'elementKey': 'ehr_group399',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -17024,7 +17183,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group401',
+              'elementKey': 'ehr_group400',
               'label': 'Microsopy',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -17232,7 +17391,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group379',
+              'elementKey': 'ehr_group378',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17243,7 +17402,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group380',
+              'elementKey': 'ehr_group379',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17397,7 +17556,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group381',
+              'elementKey': 'ehr_group380',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17408,7 +17567,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group382',
+              'elementKey': 'ehr_group381',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17589,7 +17748,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group402',
+            'elementKey': 'ehr_group401',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17691,7 +17850,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group403',
+            'elementKey': 'ehr_group402',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17915,7 +18074,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group404',
+              'elementKey': 'ehr_group403',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17926,7 +18085,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group405',
+              'elementKey': 'ehr_group404',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18124,7 +18283,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group406',
+              'elementKey': 'ehr_group405',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18135,7 +18294,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group407',
+              'elementKey': 'ehr_group406',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -18350,7 +18509,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group408',
+              'elementKey': 'ehr_group407',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18361,7 +18520,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group409',
+              'elementKey': 'ehr_group408',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18733,11 +18892,11 @@ const DEFS = {
         'fqn': 'testPage.textDateDate'
       },
       {
-        'elementKey': 'spacer415',
+        'elementKey': 'spacer414',
         'formIndex': '3',
         'inputType': 'spacer',
         'label': 'TextDate',
-        'fqn': 'testPage.spacer415'
+        'fqn': 'testPage.spacer414'
       },
       {
         'elementKey': 'name',
@@ -18763,7 +18922,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group410',
+            'elementKey': 'ehr_group409',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-1',
             'gIndex': '1',
@@ -18772,7 +18931,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group411',
+            'elementKey': 'ehr_group410',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '2',
@@ -18790,7 +18949,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group412',
+            'elementKey': 'ehr_group411',
             'label': 'Second group',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '3',
@@ -18868,7 +19027,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group413',
+              'elementKey': 'ehr_group412',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -18897,7 +19056,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group414',
+            'elementKey': 'ehr_group413',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
@@ -18908,7 +19067,7 @@ const DEFS = {
               'form2_time',
               'textDate',
               'textDateDate',
-              'spacer415',
+              'spacer414',
               'name',
               'place'
             ]
@@ -19259,13 +19418,13 @@ const DEFS = {
         'fqn': 'testTable.cd1Date'
       },
       {
-        'elementKey': 'spacer421',
+        'elementKey': 'spacer420',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 1',
         'tableColumn': '2',
         'tableLabel': 'Chk 1',
-        'fqn': 'testTable.spacer421'
+        'fqn': 'testTable.spacer420'
       },
       {
         'elementKey': 'cd2',
@@ -19287,13 +19446,13 @@ const DEFS = {
         'fqn': 'testTable.cd2Date'
       },
       {
-        'elementKey': 'spacer422',
+        'elementKey': 'spacer421',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 2',
         'tableColumn': '3',
         'tableLabel': 'Chk 2',
-        'fqn': 'testTable.spacer422'
+        'fqn': 'testTable.spacer421'
       },
       {
         'elementKey': 'td1',
@@ -19314,13 +19473,13 @@ const DEFS = {
         'fqn': 'testTable.td1Date'
       },
       {
-        'elementKey': 'spacer423',
+        'elementKey': 'spacer422',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'TextDate',
         'tableColumn': '4',
         'tableLabel': 'Txt 1',
-        'fqn': 'testTable.spacer423'
+        'fqn': 'testTable.spacer422'
       },
       {
         'elementKey': 'referralName',
@@ -19641,7 +19800,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group416',
+              'elementKey': 'ehr_group415',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -19658,7 +19817,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group417',
+              'elementKey': 'ehr_group416',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -19694,7 +19853,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group418',
+              'elementKey': 'ehr_group417',
               'formOption': '1',
               'formCss': 'full-width',
               'gIndex': '3',
@@ -19774,7 +19933,7 @@ const DEFS = {
             'items': [
               'cd1',
               'cd1Date',
-              'spacer421'
+              'spacer420'
             ]
           },
           {
@@ -19783,7 +19942,7 @@ const DEFS = {
             'items': [
               'cd2',
               'cd2Date',
-              'spacer422'
+              'spacer421'
             ]
           },
           {
@@ -19792,7 +19951,7 @@ const DEFS = {
             'items': [
               'td1',
               'td1Date',
-              'spacer423'
+              'spacer422'
             ]
           },
           {
@@ -19826,7 +19985,7 @@ const DEFS = {
           'formKey': 'stacked',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group419',
+              'elementKey': 'ehr_group418',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -19837,23 +19996,23 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group420',
+              'elementKey': 'ehr_group419',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
                 'cd1',
                 'cd1Date',
-                'spacer421',
+                'spacer420',
                 'cd2',
                 'cd2Date',
-                'spacer422',
+                'spacer421',
                 'td1',
                 'td1Date',
-                'spacer423'
+                'spacer422'
               ]
             },
             {
-              'elementKey': 'ehr_group424',
+              'elementKey': 'ehr_group423',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '3',
               'gChildren': [
@@ -19892,13 +20051,13 @@ const DEFS = {
           'stacked_time',
           'cd1',
           'cd1Date',
-          'spacer421',
+          'spacer420',
           'cd2',
           'cd2Date',
-          'spacer422',
+          'spacer421',
           'td1',
           'td1Date',
-          'spacer423',
+          'spacer422',
           'referralName',
           'referralProfession',
           'appointmentDate',
@@ -26608,7 +26767,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group375',
+              'elementKey': 'ehr_group374',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -26619,7 +26778,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group376',
+              'elementKey': 'ehr_group375',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -31770,13 +31929,6 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.form_label362'
       },
       {
-        'elementKey': 'form_label363',
-        'formIndex': '1',
-        'inputType': 'form_label',
-        'label': 'L, H, CH, Cl',
-        'fqn': 'medLabUrinalysis.form_label363'
-      },
-      {
         'elementKey': 'uqcPendAnal_1',
         'formIndex': '1',
         'inputType': 'text',
@@ -31791,150 +31943,46 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.uqcPendResult_1'
       },
       {
-        'elementKey': 'uqcPendFlag_1',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '54',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_1'
-      },
-      {
         'elementKey': 'uqcPendAnal_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '55',
+        'tableColumn': '54',
         'fqn': 'medLabUrinalysis.uqcPendAnal_2'
       },
       {
         'elementKey': 'uqcPendResult_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '56',
+        'tableColumn': '55',
         'fqn': 'medLabUrinalysis.uqcPendResult_2'
-      },
-      {
-        'elementKey': 'uqcPendFlag_2',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '57',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_2'
       },
       {
         'elementKey': 'uqcPendAnal_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '58',
+        'tableColumn': '56',
         'fqn': 'medLabUrinalysis.uqcPendAnal_3'
       },
       {
         'elementKey': 'uqcPendResult_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '59',
+        'tableColumn': '57',
         'fqn': 'medLabUrinalysis.uqcPendResult_3'
-      },
-      {
-        'elementKey': 'uqcPendFlag_3',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '60',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_3'
       },
       {
         'elementKey': 'uqcPendAnal_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '61',
+        'tableColumn': '58',
         'fqn': 'medLabUrinalysis.uqcPendAnal_4'
       },
       {
         'elementKey': 'uqcPendResult_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '62',
+        'tableColumn': '59',
         'fqn': 'medLabUrinalysis.uqcPendResult_4'
-      },
-      {
-        'elementKey': 'uqcPendFlag_4',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '63',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_4'
       }
     ],
     'pageElements': {
@@ -32325,61 +32373,37 @@ const DEFS = {
           {
             'ehr_list_index': '54',
             'items': [
-              'uqcPendFlag_1'
+              'uqcPendAnal_2'
             ]
           },
           {
             'ehr_list_index': '55',
             'items': [
-              'uqcPendAnal_2'
+              'uqcPendResult_2'
             ]
           },
           {
             'ehr_list_index': '56',
             'items': [
-              'uqcPendResult_2'
+              'uqcPendAnal_3'
             ]
           },
           {
             'ehr_list_index': '57',
             'items': [
-              'uqcPendFlag_2'
+              'uqcPendResult_3'
             ]
           },
           {
             'ehr_list_index': '58',
             'items': [
-              'uqcPendAnal_3'
+              'uqcPendAnal_4'
             ]
           },
           {
             'ehr_list_index': '59',
             'items': [
-              'uqcPendResult_3'
-            ]
-          },
-          {
-            'ehr_list_index': '60',
-            'items': [
-              'uqcPendFlag_3'
-            ]
-          },
-          {
-            'ehr_list_index': '61',
-            'items': [
-              'uqcPendAnal_4'
-            ]
-          },
-          {
-            'ehr_list_index': '62',
-            'items': [
               'uqcPendResult_4'
-            ]
-          },
-          {
-            'ehr_list_index': '63',
-            'items': [
-              'uqcPendFlag_4'
             ]
           }
         ],
@@ -32527,19 +32551,14 @@ const DEFS = {
                 'form_label360',
                 'form_label361',
                 'form_label362',
-                'form_label363',
                 'uqcPendAnal_1',
                 'uqcPendResult_1',
-                'uqcPendFlag_1',
                 'uqcPendAnal_2',
                 'uqcPendResult_2',
-                'uqcPendFlag_2',
                 'uqcPendAnal_3',
                 'uqcPendResult_3',
-                'uqcPendFlag_3',
                 'uqcPendAnal_4',
-                'uqcPendResult_4',
-                'uqcPendFlag_4'
+                'uqcPendResult_4'
               ]
             }
           ],
@@ -32606,16 +32625,12 @@ const DEFS = {
             'uqcSomeQcUnacceptable': '',
             'uqcPendAnal_1': '',
             'uqcPendResult_1': '',
-            'uqcPendFlag_1': '',
             'uqcPendAnal_2': '',
             'uqcPendResult_2': '',
-            'uqcPendFlag_2': '',
             'uqcPendAnal_3': '',
             'uqcPendResult_3': '',
-            'uqcPendFlag_3': '',
             'uqcPendAnal_4': '',
-            'uqcPendResult_4': '',
-            'uqcPendFlag_4': ''
+            'uqcPendResult_4': ''
           }
         },
         'tableChildren': [
@@ -32676,16 +32691,12 @@ const DEFS = {
           'uqcSomeQcUnacceptable',
           'uqcPendAnal_1',
           'uqcPendResult_1',
-          'uqcPendFlag_1',
           'uqcPendAnal_2',
           'uqcPendResult_2',
-          'uqcPendFlag_2',
           'uqcPendAnal_3',
           'uqcPendResult_3',
-          'uqcPendFlag_3',
           'uqcPendAnal_4',
-          'uqcPendResult_4',
-          'uqcPendFlag_4'
+          'uqcPendResult_4'
         ],
         'hasRecHeader': true
       },
@@ -34199,7 +34210,7 @@ const DEFS = {
           'formKey': 'mlAccessioning',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group364',
+              'elementKey': 'ehr_group363',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34210,7 +34221,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group365',
+              'elementKey': 'ehr_group364',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34227,7 +34238,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group366',
+              'elementKey': 'ehr_group365',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
               'gChildren': [
@@ -34344,7 +34355,7 @@ const DEFS = {
           'formKey': 'mlChain',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group367',
+              'elementKey': 'ehr_group366',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34355,7 +34366,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group368',
+              'elementKey': 'ehr_group367',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34461,7 +34472,7 @@ const DEFS = {
           'formKey': 'mlTestStatus',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group369',
+              'elementKey': 'ehr_group368',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34472,7 +34483,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group370',
+              'elementKey': 'ehr_group369',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [

--- a/client/src/ehr-definitions/ehr-page-defs.js
+++ b/client/src/ehr-definitions/ehr-page-defs.js
@@ -12723,12 +12723,12 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
-        'elementKey': 'med_second_signature',
+        'elementKey': 'med_secondSig',
         'formIndex': '2',
         'inputType': 'checkbox',
-        'label': 'Second signature require',
+        'label': 'Second signature required',
         'tableColumn': '8',
-        'fqn': 'medicationOrders.med_second_signature'
+        'fqn': 'medicationOrders.med_secondSig'
       },
       {
         'elementKey': 'med_scheduled',
@@ -13214,7 +13214,7 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_second_signature'
+              'med_secondSig'
             ]
           },
           {
@@ -13322,7 +13322,7 @@ const DEFS = {
               'gChildren': [
                 'med_medication',
                 'med_dose',
-                'med_second_signature'
+                'med_secondSig'
               ]
             },
             {
@@ -13386,7 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
-            'med_second_signature': '',
+            'med_secondSig': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13416,7 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
-          'med_second_signature',
+          'med_secondSig',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13629,7 +13629,7 @@ const DEFS = {
         'formIndex': '2',
         'embedRef': 'medicationOrders.medicationOrdersTable',
         'inputType': 'ehr_embedded',
-        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id]',
+        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id mo_secondSig]',
         'fqn': 'medAdminRec.med_order_embedded'
       },
       {
@@ -13689,6 +13689,16 @@ const DEFS = {
         'fqn': 'medAdminRec.mo_id'
       },
       {
+        'elementKey': 'mo_secondSig',
+        'calculationType': 'embedValue(medicationOrders, medicationOrdersTable, med_secondSig)',
+        'formIndex': '2',
+        'formCss': 'grid-span-3-columns',
+        'inputType': 'calculatedBool',
+        'label': 'Second signature required',
+        'tableColumn': '6',
+        'fqn': 'medAdminRec.mo_secondSig'
+      },
+      {
         'elementKey': 'mar_status',
         'formIndex': '2',
         'inputType': 'select',
@@ -13711,7 +13721,7 @@ const DEFS = {
             'text': 'Skipped'
           }
         ],
-        'tableColumn': '6',
+        'tableColumn': '7',
         'fqn': 'medAdminRec.mar_status'
       },
       {
@@ -13719,7 +13729,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'tableColumn': '7',
+        'tableColumn': '8',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
@@ -13789,7 +13799,7 @@ const DEFS = {
             'text': 'Vaginal'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medAdminRec.mar_route'
       },
       {
@@ -13831,7 +13841,7 @@ const DEFS = {
             'text': 'Subcutaneous'
           }
         ],
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_injectionLocation'
       },
       {
@@ -13839,8 +13849,16 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'fqn': 'medAdminRec.mar_comments'
+      },
+      {
+        'elementKey': 'mar_secSigName',
+        'formIndex': '2',
+        'inputType': 'text',
+        'label': 'Second Signature',
+        'tableColumn': '12',
+        'fqn': 'medAdminRec.mar_secSigName'
       }
     ],
     'pageElements': {
@@ -14028,31 +14046,43 @@ const DEFS = {
           {
             'ehr_list_index': '6',
             'items': [
-              'mar_status'
+              'mo_secondSig'
             ]
           },
           {
             'ehr_list_index': '7',
             'items': [
-              'mar_dose'
+              'mar_status'
             ]
           },
           {
             'ehr_list_index': '8',
             'items': [
-              'mar_route'
+              'mar_dose'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'mar_injectionLocation'
+              'mar_route'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '11',
+            'items': [
               'mar_comments'
+            ]
+          },
+          {
+            'ehr_list_index': '12',
+            'items': [
+              'mar_secSigName'
             ]
           }
         ],
@@ -14094,7 +14124,8 @@ const DEFS = {
                 'mo_timing',
                 'mo_schedDay',
                 'mo_schedTime',
-                'mo_id'
+                'mo_id',
+                'mo_secondSig'
               ]
             },
             {
@@ -14124,6 +14155,15 @@ const DEFS = {
               'gChildren': [
                 'mar_comments'
               ]
+            },
+            {
+              'elementKey': 'mar_group_sec',
+              'dependentOn': 'visble:mo_secondSig',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '7',
+              'gChildren': [
+                'mar_secSigName'
+              ]
             }
           ],
           'ehr_data': {
@@ -14138,11 +14178,13 @@ const DEFS = {
             'mo_schedDay': '',
             'mo_schedTime': '',
             'mo_id': '',
+            'mo_secondSig': '',
             'mar_status': '',
             'mar_dose': '',
             'mar_route': '',
             'mar_injectionLocation': '',
-            'mar_comments': ''
+            'mar_comments': '',
+            'mar_secSigName': ''
           }
         },
         'tableChildren': [
@@ -14155,11 +14197,13 @@ const DEFS = {
           'mo_timing',
           'mo_schedDay',
           'mo_schedTime',
+          'mo_secondSig',
           'mar_status',
           'mar_dose',
           'mar_route',
           'mar_injectionLocation',
-          'mar_comments'
+          'mar_comments',
+          'mar_secSigName'
         ],
         'hasRecHeader': true
       }

--- a/client/src/ehr-definitions/ehr-types.js
+++ b/client/src/ehr-definitions/ehr-types.js
@@ -23,6 +23,7 @@ const EhrTypes = {
     checkbox: 'checkbox',
     boxcheckset: 'boxcheckset',
     select: 'select',
+    calculatedBool: 'calculatedBool',
     calculatedText: 'calculatedText',
     calculatedValue: 'calculatedValue',
     checkset: 'checkset',

--- a/client/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/client/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -65,7 +65,6 @@ export class MedOrder {
    * @returns {string}
    */
   medOrderSummary () {
-    console.log('mmos', this._e)
     const list = []
     list.push(this.medName)
     list.push(this.dose)

--- a/client/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/client/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -1,5 +1,6 @@
 import { MED_ORDERS_PAGE_KEY, MED_ORDERS_TABLE_KEY } from '../ehr-defs-grid'
 import { hourStringToHour } from './mar-model'
+import { makeHumanTableCell } from '../ehr-def-utils'
 
 export class MedOrders {
   constructor (ehrDataModel) {
@@ -26,12 +27,15 @@ export class MedOrders {
 export class MedOrder {
   constructor (eData) {
     this._e = {}
-    const {med_dose, medicationOrdersTable_id, med_instructions, med_injectionLocation,
+    let {med_dose, medicationOrdersTable_id, med_instructions, med_injectionLocation,
       med_scheduled,
       med_prnMaxDosage, med_medication,
       med_reason, med_route, med_timing,
       med_time1, med_time2, med_time3, med_time4, med_time5, med_time6
     } = eData
+    // translate the key data into human readable
+    med_route = makeHumanTableCell( 'medicationOrders', 'med_route', 'select', med_route)
+    med_injectionLocation = makeHumanTableCell( 'medicationOrders', 'med_injectionLocation', 'select', med_injectionLocation)
     this._e.day = eData['medicationOrdersTable_day']
     this._e.time = eData['medicationOrdersTable_time']
     this._e.name = eData['medicationOrdersTable_name']
@@ -61,12 +65,14 @@ export class MedOrder {
    * @returns {string}
    */
   medOrderSummary () {
+    console.log('mmos', this._e)
     const list = []
     list.push(this.medName)
     list.push(this.dose)
-    list.push(this.route)
     list.push(this.schedule)
-    return list.join(' ')
+    list.push(this.route)
+    list.push(this.location)
+    return list.join(', ')
   }
 
   /**

--- a/client/src/helpers/page-controller.js
+++ b/client/src/helpers/page-controller.js
@@ -81,6 +81,8 @@ async  function onPageChange (toRoute) {
     // See the last sections of this page change handler for the case a user has
     // entered the ehr demo and has paged to another ehr page
     await EhrOnlyDemo.selectCaseStudy(demoOnlyKey)
+    await store.dispatch('mPatientStore/ehrOnlyDemo', demoOnlyKey)
+
     if (dbApp) console.log('loaded demo only ', demoOnlyKey)
     EventBus.$emit(PAGE_DATA_REFRESH_EVENT)
     return perfExit(perfStat)

--- a/client/src/inside/components/page/EhrElementCalculatedBool.vue
+++ b/client/src/inside/components/page/EhrElementCalculatedBool.vue
@@ -1,0 +1,67 @@
+<template lang="pug">
+  div(class="checkbox_wrapper", :class='formCss')
+    input(class="checkbox",
+      type="checkbox",
+      disabled,
+      :name="elementKey",
+      v-model="inputVal",
+      v-on:change="dependentUIEvent()")
+    ehr-page-form-label(
+      :ehrHelp="ehrHelp",
+      :element="element",
+      css="checkbox_label, check-label")
+
+</template>
+
+<script>
+import EventBus from '@/helpers/event-bus'
+import { FORM_INPUT_EVENT } from '@/helpers/event-bus'
+import EhrElementCommon from '@/inside/components/page/EhrElementCommon.vue'
+import { ehrCalculateBoolProperty } from '@/inside/components/page/ehr-calc-text'
+
+export default {
+  extends: EhrElementCommon,
+  inject: [ 'pageDataKey' ],
+  props: {
+    ehrHelp: { type: Object },
+    elementKey: { type: String }
+  },
+  data () {
+    return {
+      value: '',
+      eventHandler: {}
+    }
+  },
+  methods: {
+    receiveEvent (eData) {
+      let pageDataKey = this.pageDataKey
+      let elementKey = this.element.elementKey
+      let srcValues = this.ehrHelp.getActiveData()
+      let value = ehrCalculateBoolProperty(pageDataKey, elementKey, srcValues)
+      // put value into the inputs so the dialog save can preserve the result
+      this.ehrHelp.stashActiveData(elementKey, value)
+      this.value = value
+    }
+  },
+  mounted: function () {
+    const _this = this
+    // get initial value
+    this.value = ''// this.inputs[elementKey]
+    // set up event handler
+    this.eventHandler = function (eData) {
+      _this.receiveEvent(eData)
+    }
+    EventBus.$on(FORM_INPUT_EVENT, this.eventHandler)
+  },
+  beforeDestroy: function () {
+    if (this.eventHandler) {
+      EventBus.$off(FORM_INPUT_EVENT, this.eventHandler)
+    }
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.calculated_value {
+}
+</style>

--- a/client/src/inside/components/page/EhrElementForm.vue
+++ b/client/src/inside/components/page/EhrElementForm.vue
@@ -11,6 +11,9 @@
         fas-icon(class="linkIcon", icon="file-pdf")
         span {{assetName()}}
 
+
+    ehr-element-calculated-bool(v-else-if="isType('calculatedBool')", :elementKey="elementKey", :ehrHelp="ehrHelp" )
+
     ehr-element-calculated(v-else-if="isType('calculatedValue')", :elementKey="elementKey", :ehrHelp="ehrHelp" )
 
     ehr-element-calculated-text(v-else-if="isType('calculatedText')", :elementKey="elementKey", :ehrHelp="ehrHelp" )
@@ -176,11 +179,13 @@ import EhrElementSelect from '@/inside/components/page/EhrElementSelect.vue'
 import EhrElementRadioset from '@/inside/components/page/EhrElementRadioset.vue'
 import EhrElementBoxCheckset from '@/inside/components/page/EhrElementBoxCheckset.vue'
 import EhrElementCalculatedText from '@/inside/components/page/EhrElementCalculatedText.vue'
+import EhrElementCalculatedBool from '@/inside/components/page/EhrElementCalculatedBool.vue'
 
 export default {
   name: 'EhrElementForm',
   extends: EhrElementCommon,
   components: {
+    EhrElementCalculatedBool,
     EhrElementCalculatedText,
     EhrElementBoxCheckset,
     EhrElementRadioset,

--- a/client/src/inside/components/page/ehr-calc-text.js
+++ b/client/src/inside/components/page/ehr-calc-text.js
@@ -1,37 +1,37 @@
 import EhrDefs from '@/ehr-definitions/ehr-defs-grid'
 
 
-// export for testing
 export function ehrCalculateTextProperty (pageDataKey, targetKey, srcValues) {
+  const ectp = false
   let opts = EhrDefs.getChildElements(pageDataKey, 'elementKey', targetKey, 'options')
-  console.log('ectp', 'pageDataKey, targetKey', pageDataKey, targetKey)
-  console.log('ectp', 'opts', targetKey, opts)
+  if ( exbp ) console.log('ectp', 'pageDataKey, targetKey', pageDataKey, targetKey)
+  if ( exbp ) console.log('ectp', 'opts', targetKey, opts)
   if (!opts) {
     let msg = `Ehr calc text unexpected missing options for key ${targetKey}`
     console.log('ectp', msg)
     throw new Error(msg)
   }
   opts = opts[0]
-  console.log('ectp', 'opts', targetKey, opts)
+  if ( exbp ) console.log('ectp', 'opts', targetKey, opts)
   let sourceFieldToMatchOn = 'passToFunction'
   let desiredSourceProperty = 'elementKey'
   let srcKeys = EhrDefs.getChildElements(pageDataKey, sourceFieldToMatchOn, targetKey, desiredSourceProperty)
-  console.log('ectp', 'srcKeys', srcKeys)
+  if ( exbp ) console.log('ectp', 'srcKeys', srcKeys)
   if (srcKeys.length === 0) {
     let msg = `Ehr calc unexpected empty set of source keys for key ${targetKey} and calc type ${calculationType}`
-    console.log('ectp', msg)
-    console.log('ectp', 'pageDataKey, sourceFieldToMatchOn, targetKey',pageDataKey, sourceFieldToMatchOn, targetKey)
+    if ( exbp ) console.log('ectp', msg)
+    if ( exbp ) console.log('ectp', 'pageDataKey, sourceFieldToMatchOn, targetKey',pageDataKey, sourceFieldToMatchOn, targetKey)
     throw new Error(msg)
   }
   let values = []
   srcKeys.forEach(key => {
     let srcVal = srcValues[key]
-    console.log('ectp', 'srcKey, srcVal', key, srcVal)
+    if ( exbp ) console.log('ectp', 'srcKey, srcVal', key, srcVal)
     if(srcVal) {
       srcVal = srcVal.toLowerCase()
-      console.log('ectp', 'srcKey, srcVal', key, srcVal)
+      if ( exbp ) console.log('ectp', 'srcKey, srcVal', key, srcVal)
       const mappedValue = opts.find( opt => opt.key === srcVal)
-      console.log('ectp', 'mappedValue', mappedValue)
+      if ( exbp ) console.log('ectp', 'mappedValue', mappedValue)
       let text = mappedValue.text
       values.push(text)
     } else {
@@ -39,6 +39,34 @@ export function ehrCalculateTextProperty (pageDataKey, targetKey, srcValues) {
     }
   })
   let result = values.join(' ')
-  console.log('ectp', 'results "' + result +'"')
+  if ( exbp ) console.log('ectp', 'results "' + result +'"')
+  return result
+}
+
+
+
+// export for testing
+export function ehrCalculateBoolProperty (pageDataKey, targetKey, srcValues) {
+  const exbp = false
+  if ( exbp ) console.log('exbp', 'pageDataKey, targetKey', pageDataKey, targetKey)
+  let sourceFieldToMatchOn = 'passToFunction'
+  let desiredSourceProperty = 'elementKey'
+  let srcKeys = EhrDefs.getChildElements(pageDataKey, sourceFieldToMatchOn, targetKey, desiredSourceProperty)
+  if ( exbp ) console.log('exbp', 'srcKeys', srcKeys)
+  if (srcKeys.length === 0) {
+    let msg = `Ehr calc unexpected empty set of source keys for key ${targetKey} and calc type ${calculationType}`
+    console.log('exbp', msg)
+    console.log('exbp', 'pageDataKey, sourceFieldToMatchOn, targetKey',pageDataKey, sourceFieldToMatchOn, targetKey)
+    throw new Error(msg)
+  }
+  if ( exbp ) console.log('exbp srcValues', srcValues)
+  let bVal = true
+  srcKeys.forEach(key => {
+    let srcVal = srcValues[key]
+    bVal = bVal && srcVal
+    if ( exbp ) console.log('exbp', 'srcKey, srcVal', key, srcVal)
+  })
+  let result = bVal
+  if ( exbp ) console.log('exbp', 'results "' + result +'"')
   return result
 }

--- a/client/src/scss/styles/_forms.scss
+++ b/client/src/scss/styles/_forms.scss
@@ -275,6 +275,7 @@ input[type="checkbox"]{
   margin-right: 5px;
   max-width: 1rem;
   vertical-align: middle;
+  box-shadow: none;
 }
 
 /* A radio set is a group of radio inputs with labels. */
@@ -340,6 +341,7 @@ select, .select {
 .ehr-group-wrapper {
   .ehr-group-for {
     margin-bottom: 2px;
+    margin-right: 5px; // space between elements
     //border: 1px solid blue;
   }
 }

--- a/client/src/store/modules/mPatientStore.js
+++ b/client/src/store/modules/mPatientStore.js
@@ -59,6 +59,9 @@ const actions = {
       }
     }
   },
+  async ehrOnlyDemo ( context, seedId) {
+    await context.commit('_setCurrentPatientObjectId', seedId)
+  },
   async addSeedToActivePatientList (context, seed) {
     if (this.currentPatientObjectId && this.currentPatientObjectId === seed._id) {
       // console.log('mps Patient is already in the list and it is the currently selected object', seed)

--- a/ehr-workspace/src/ehr-definitions/ehr-page-defs.js
+++ b/ehr-workspace/src/ehr-definitions/ehr-page-defs.js
@@ -12723,6 +12723,14 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
+        'elementKey': 'med_second_signature',
+        'formIndex': '2',
+        'inputType': 'checkbox',
+        'label': 'Second signature require',
+        'tableColumn': '8',
+        'fqn': 'medicationOrders.med_second_signature'
+      },
+      {
         'elementKey': 'med_scheduled',
         'formIndex': '2',
         'inputType': 'select',
@@ -12765,7 +12773,7 @@ const DEFS = {
             'text': 'Q1H'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medicationOrders.med_scheduled'
       },
       {
@@ -12773,7 +12781,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Max dosage',
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medicationOrders.med_prnMaxDosage'
       },
       {
@@ -12782,7 +12790,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 1',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time1'
       },
@@ -12792,7 +12800,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 2',
-        'tableColumn': '11',
+        'tableColumn': '12',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time2'
       },
@@ -12802,7 +12810,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 3',
-        'tableColumn': '12',
+        'tableColumn': '13',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time3'
       },
@@ -12812,7 +12820,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 4',
-        'tableColumn': '13',
+        'tableColumn': '14',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time4'
       },
@@ -12822,7 +12830,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 5',
-        'tableColumn': '14',
+        'tableColumn': '15',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time5'
       },
@@ -12832,7 +12840,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 6',
-        'tableColumn': '15',
+        'tableColumn': '16',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time6'
       },
@@ -12841,7 +12849,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Continuous description',
-        'tableColumn': '16',
+        'tableColumn': '17',
         'fqn': 'medicationOrders.med_continuous_description'
       },
       {
@@ -12850,7 +12858,7 @@ const DEFS = {
         'inputType': 'textarea',
         'label': 'Instructions',
         'suffix': 'medAdminRec',
-        'tableColumn': '17',
+        'tableColumn': '18',
         'tableLabel': 'Instructions',
         'fqn': 'medicationOrders.med_instructions',
         'suffixText': '<p>medAdminRec</p>',
@@ -13206,60 +13214,66 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_scheduled'
+              'med_second_signature'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'med_prnMaxDosage'
+              'med_scheduled'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
-              'med_time1'
+              'med_prnMaxDosage'
             ]
           },
           {
             'ehr_list_index': '11',
             'items': [
-              'med_time2'
+              'med_time1'
             ]
           },
           {
             'ehr_list_index': '12',
             'items': [
-              'med_time3'
+              'med_time2'
             ]
           },
           {
             'ehr_list_index': '13',
             'items': [
-              'med_time4'
+              'med_time3'
             ]
           },
           {
             'ehr_list_index': '14',
             'items': [
-              'med_time5'
+              'med_time4'
             ]
           },
           {
             'ehr_list_index': '15',
             'items': [
-              'med_time6'
+              'med_time5'
             ]
           },
           {
             'ehr_list_index': '16',
+            'items': [
+              'med_time6'
+            ]
+          },
+          {
+            'ehr_list_index': '17',
             'items': [
               'med_continuous_description'
             ]
           },
           {
             'label': 'Instructions',
-            'ehr_list_index': '17',
+            'ehr_list_index': '18',
             'items': [
               'med_instructions'
             ]
@@ -13307,7 +13321,8 @@ const DEFS = {
               'gIndex': '4',
               'gChildren': [
                 'med_medication',
-                'med_dose'
+                'med_dose',
+                'med_second_signature'
               ]
             },
             {
@@ -13371,6 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
+            'med_second_signature': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13400,6 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
+          'med_second_signature',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13676,7 +13693,6 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'select',
         'label': 'Status',
-        'mandatory': true,
         'options': [
           {
             'key': 'Administered',
@@ -13703,17 +13719,127 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'mandatory': true,
         'tableColumn': '7',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
+        'elementKey': 'mar_route',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Route',
+        'options': [
+          {
+            'key': 'oral',
+            'text': 'Oral'
+          },
+          {
+            'key': 'bucc',
+            'text': 'Buccal'
+          },
+          {
+            'key': 'cuta',
+            'text': 'Cutaneous'
+          },
+          {
+            'key': 'impl',
+            'text': 'Implant'
+          },
+          {
+            'key': 'inha',
+            'text': 'Inhalation'
+          },
+          {
+            'key': 'inje',
+            'text': 'Injection'
+          },
+          {
+            'key': 'intra',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'nasa',
+            'text': 'Nasal'
+          },
+          {
+            'key': 'nebu',
+            'text': 'Nebulization'
+          },
+          {
+            'key': 'ocul',
+            'text': 'Ocular'
+          },
+          {
+            'key': 'otic',
+            'text': 'Otic'
+          },
+          {
+            'key': 'rect',
+            'text': 'Rectal'
+          },
+          {
+            'key': 'subl',
+            'text': 'Sublingual'
+          },
+          {
+            'key': 'tran',
+            'text': 'Transdermal'
+          },
+          {
+            'key': 'vagi',
+            'text': 'Vaginal'
+          }
+        ],
+        'tableColumn': '8',
+        'fqn': 'medAdminRec.mar_route'
+      },
+      {
+        'elementKey': 'mar_injectionLocation',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Injection location',
+        'options': [
+          {
+            'key': 'arterial',
+            'text': 'Arterial'
+          },
+          {
+            'key': 'epidural',
+            'text': 'Epidural'
+          },
+          {
+            'key': 'intramuscular',
+            'text': 'Intramuscular'
+          },
+          {
+            'key': 'intraosseous',
+            'text': 'Intraosseous'
+          },
+          {
+            'key': 'intraperitoneal',
+            'text': 'Intraperitoneal'
+          },
+          {
+            'key': 'intrathecal',
+            'text': 'Intrathecal'
+          },
+          {
+            'key': 'intravenous',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'subcutaneous',
+            'text': 'Subcutaneous'
+          }
+        ],
+        'tableColumn': '9',
+        'fqn': 'medAdminRec.mar_injectionLocation'
+      },
+      {
         'elementKey': 'mar_comments',
         'formIndex': '2',
-        'formCss': 'grid-span-3-columns',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '8',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_comments'
       }
     ],
@@ -13914,6 +14040,18 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
+              'mar_route'
+            ]
+          },
+          {
+            'ehr_list_index': '9',
+            'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '10',
+            'items': [
               'mar_comments'
             ]
           }
@@ -13967,6 +14105,23 @@ const DEFS = {
               'gChildren': [
                 'mar_status',
                 'mar_dose',
+                'mar_route'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_inje',
+              'dependentOn': 'visble:mar_route=inje,intra',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '5',
+              'gChildren': [
+                'mar_injectionLocation'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_notes',
+              'formCss': 'grid-left-to-right-1',
+              'gIndex': '6',
+              'gChildren': [
                 'mar_comments'
               ]
             }
@@ -13985,6 +14140,8 @@ const DEFS = {
             'mo_id': '',
             'mar_status': '',
             'mar_dose': '',
+            'mar_route': '',
+            'mar_injectionLocation': '',
             'mar_comments': ''
           }
         },
@@ -14000,6 +14157,8 @@ const DEFS = {
           'mo_schedTime',
           'mar_status',
           'mar_dose',
+          'mar_route',
+          'mar_injectionLocation',
           'mar_comments'
         ],
         'hasRecHeader': true
@@ -14358,7 +14517,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group371',
+              'elementKey': 'ehr_group370',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14369,7 +14528,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group372',
+              'elementKey': 'ehr_group371',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -14578,7 +14737,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group373',
+              'elementKey': 'ehr_group372',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14589,7 +14748,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group374',
+              'elementKey': 'ehr_group373',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -14752,7 +14911,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group377',
+              'elementKey': 'ehr_group376',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14763,7 +14922,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group378',
+              'elementKey': 'ehr_group377',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -15986,7 +16145,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group383',
+              'elementKey': 'ehr_group382',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -15997,7 +16156,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group384',
+              'elementKey': 'ehr_group383',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -16130,7 +16289,7 @@ const DEFS = {
           'formKey': 'labResultHematology',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group385',
+              'elementKey': 'ehr_group384',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16141,7 +16300,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group386',
+              'elementKey': 'ehr_group385',
               'label': 'Hematology',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16155,7 +16314,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group387',
+              'elementKey': 'ehr_group386',
               'label': 'WBC Types',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16271,7 +16430,7 @@ const DEFS = {
           'formKey': 'labResultCoagulation',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group388',
+              'elementKey': 'ehr_group387',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16282,7 +16441,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group389',
+              'elementKey': 'ehr_group388',
               'label': 'Coagulation',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16531,7 +16690,7 @@ const DEFS = {
           'formKey': 'labResultGeneral',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group390',
+              'elementKey': 'ehr_group389',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16542,7 +16701,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group391',
+              'elementKey': 'ehr_group390',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16561,7 +16720,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group392',
+              'elementKey': 'ehr_group391',
               'label': 'Renal Profile',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16572,7 +16731,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group393',
+              'elementKey': 'ehr_group392',
               'label': 'Liver function',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -16588,7 +16747,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group394',
+              'elementKey': 'ehr_group393',
               'label': 'Blood gas tests',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '5',
@@ -16601,7 +16760,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group395',
+              'elementKey': 'ehr_group394',
               'label': 'Group and screen',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '6',
@@ -16739,7 +16898,7 @@ const DEFS = {
           'formKey': 'troponinTable',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group396',
+              'elementKey': 'ehr_group395',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16750,7 +16909,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group397',
+              'elementKey': 'ehr_group396',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -16975,7 +17134,7 @@ const DEFS = {
           'formKey': 'labResultUrine',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group398',
+              'elementKey': 'ehr_group397',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16986,7 +17145,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group399',
+              'elementKey': 'ehr_group398',
               'label': 'General',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16998,7 +17157,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group400',
+              'elementKey': 'ehr_group399',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -17024,7 +17183,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group401',
+              'elementKey': 'ehr_group400',
               'label': 'Microsopy',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -17232,7 +17391,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group379',
+              'elementKey': 'ehr_group378',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17243,7 +17402,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group380',
+              'elementKey': 'ehr_group379',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17397,7 +17556,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group381',
+              'elementKey': 'ehr_group380',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17408,7 +17567,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group382',
+              'elementKey': 'ehr_group381',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17589,7 +17748,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group402',
+            'elementKey': 'ehr_group401',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17691,7 +17850,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group403',
+            'elementKey': 'ehr_group402',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17915,7 +18074,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group404',
+              'elementKey': 'ehr_group403',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17926,7 +18085,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group405',
+              'elementKey': 'ehr_group404',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18124,7 +18283,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group406',
+              'elementKey': 'ehr_group405',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18135,7 +18294,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group407',
+              'elementKey': 'ehr_group406',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -18350,7 +18509,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group408',
+              'elementKey': 'ehr_group407',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18361,7 +18520,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group409',
+              'elementKey': 'ehr_group408',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18733,11 +18892,11 @@ const DEFS = {
         'fqn': 'testPage.textDateDate'
       },
       {
-        'elementKey': 'spacer415',
+        'elementKey': 'spacer414',
         'formIndex': '3',
         'inputType': 'spacer',
         'label': 'TextDate',
-        'fqn': 'testPage.spacer415'
+        'fqn': 'testPage.spacer414'
       },
       {
         'elementKey': 'name',
@@ -18763,7 +18922,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group410',
+            'elementKey': 'ehr_group409',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-1',
             'gIndex': '1',
@@ -18772,7 +18931,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group411',
+            'elementKey': 'ehr_group410',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '2',
@@ -18790,7 +18949,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group412',
+            'elementKey': 'ehr_group411',
             'label': 'Second group',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '3',
@@ -18868,7 +19027,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group413',
+              'elementKey': 'ehr_group412',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -18897,7 +19056,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group414',
+            'elementKey': 'ehr_group413',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
@@ -18908,7 +19067,7 @@ const DEFS = {
               'form2_time',
               'textDate',
               'textDateDate',
-              'spacer415',
+              'spacer414',
               'name',
               'place'
             ]
@@ -19259,13 +19418,13 @@ const DEFS = {
         'fqn': 'testTable.cd1Date'
       },
       {
-        'elementKey': 'spacer421',
+        'elementKey': 'spacer420',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 1',
         'tableColumn': '2',
         'tableLabel': 'Chk 1',
-        'fqn': 'testTable.spacer421'
+        'fqn': 'testTable.spacer420'
       },
       {
         'elementKey': 'cd2',
@@ -19287,13 +19446,13 @@ const DEFS = {
         'fqn': 'testTable.cd2Date'
       },
       {
-        'elementKey': 'spacer422',
+        'elementKey': 'spacer421',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 2',
         'tableColumn': '3',
         'tableLabel': 'Chk 2',
-        'fqn': 'testTable.spacer422'
+        'fqn': 'testTable.spacer421'
       },
       {
         'elementKey': 'td1',
@@ -19314,13 +19473,13 @@ const DEFS = {
         'fqn': 'testTable.td1Date'
       },
       {
-        'elementKey': 'spacer423',
+        'elementKey': 'spacer422',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'TextDate',
         'tableColumn': '4',
         'tableLabel': 'Txt 1',
-        'fqn': 'testTable.spacer423'
+        'fqn': 'testTable.spacer422'
       },
       {
         'elementKey': 'referralName',
@@ -19641,7 +19800,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group416',
+              'elementKey': 'ehr_group415',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -19658,7 +19817,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group417',
+              'elementKey': 'ehr_group416',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -19694,7 +19853,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group418',
+              'elementKey': 'ehr_group417',
               'formOption': '1',
               'formCss': 'full-width',
               'gIndex': '3',
@@ -19774,7 +19933,7 @@ const DEFS = {
             'items': [
               'cd1',
               'cd1Date',
-              'spacer421'
+              'spacer420'
             ]
           },
           {
@@ -19783,7 +19942,7 @@ const DEFS = {
             'items': [
               'cd2',
               'cd2Date',
-              'spacer422'
+              'spacer421'
             ]
           },
           {
@@ -19792,7 +19951,7 @@ const DEFS = {
             'items': [
               'td1',
               'td1Date',
-              'spacer423'
+              'spacer422'
             ]
           },
           {
@@ -19826,7 +19985,7 @@ const DEFS = {
           'formKey': 'stacked',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group419',
+              'elementKey': 'ehr_group418',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -19837,23 +19996,23 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group420',
+              'elementKey': 'ehr_group419',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
                 'cd1',
                 'cd1Date',
-                'spacer421',
+                'spacer420',
                 'cd2',
                 'cd2Date',
-                'spacer422',
+                'spacer421',
                 'td1',
                 'td1Date',
-                'spacer423'
+                'spacer422'
               ]
             },
             {
-              'elementKey': 'ehr_group424',
+              'elementKey': 'ehr_group423',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '3',
               'gChildren': [
@@ -19892,13 +20051,13 @@ const DEFS = {
           'stacked_time',
           'cd1',
           'cd1Date',
-          'spacer421',
+          'spacer420',
           'cd2',
           'cd2Date',
-          'spacer422',
+          'spacer421',
           'td1',
           'td1Date',
-          'spacer423',
+          'spacer422',
           'referralName',
           'referralProfession',
           'appointmentDate',
@@ -26608,7 +26767,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group375',
+              'elementKey': 'ehr_group374',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -26619,7 +26778,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group376',
+              'elementKey': 'ehr_group375',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -31770,13 +31929,6 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.form_label362'
       },
       {
-        'elementKey': 'form_label363',
-        'formIndex': '1',
-        'inputType': 'form_label',
-        'label': 'L, H, CH, Cl',
-        'fqn': 'medLabUrinalysis.form_label363'
-      },
-      {
         'elementKey': 'uqcPendAnal_1',
         'formIndex': '1',
         'inputType': 'text',
@@ -31791,150 +31943,46 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.uqcPendResult_1'
       },
       {
-        'elementKey': 'uqcPendFlag_1',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '54',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_1'
-      },
-      {
         'elementKey': 'uqcPendAnal_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '55',
+        'tableColumn': '54',
         'fqn': 'medLabUrinalysis.uqcPendAnal_2'
       },
       {
         'elementKey': 'uqcPendResult_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '56',
+        'tableColumn': '55',
         'fqn': 'medLabUrinalysis.uqcPendResult_2'
-      },
-      {
-        'elementKey': 'uqcPendFlag_2',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '57',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_2'
       },
       {
         'elementKey': 'uqcPendAnal_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '58',
+        'tableColumn': '56',
         'fqn': 'medLabUrinalysis.uqcPendAnal_3'
       },
       {
         'elementKey': 'uqcPendResult_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '59',
+        'tableColumn': '57',
         'fqn': 'medLabUrinalysis.uqcPendResult_3'
-      },
-      {
-        'elementKey': 'uqcPendFlag_3',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '60',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_3'
       },
       {
         'elementKey': 'uqcPendAnal_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '61',
+        'tableColumn': '58',
         'fqn': 'medLabUrinalysis.uqcPendAnal_4'
       },
       {
         'elementKey': 'uqcPendResult_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '62',
+        'tableColumn': '59',
         'fqn': 'medLabUrinalysis.uqcPendResult_4'
-      },
-      {
-        'elementKey': 'uqcPendFlag_4',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '63',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_4'
       }
     ],
     'pageElements': {
@@ -32325,61 +32373,37 @@ const DEFS = {
           {
             'ehr_list_index': '54',
             'items': [
-              'uqcPendFlag_1'
+              'uqcPendAnal_2'
             ]
           },
           {
             'ehr_list_index': '55',
             'items': [
-              'uqcPendAnal_2'
+              'uqcPendResult_2'
             ]
           },
           {
             'ehr_list_index': '56',
             'items': [
-              'uqcPendResult_2'
+              'uqcPendAnal_3'
             ]
           },
           {
             'ehr_list_index': '57',
             'items': [
-              'uqcPendFlag_2'
+              'uqcPendResult_3'
             ]
           },
           {
             'ehr_list_index': '58',
             'items': [
-              'uqcPendAnal_3'
+              'uqcPendAnal_4'
             ]
           },
           {
             'ehr_list_index': '59',
             'items': [
-              'uqcPendResult_3'
-            ]
-          },
-          {
-            'ehr_list_index': '60',
-            'items': [
-              'uqcPendFlag_3'
-            ]
-          },
-          {
-            'ehr_list_index': '61',
-            'items': [
-              'uqcPendAnal_4'
-            ]
-          },
-          {
-            'ehr_list_index': '62',
-            'items': [
               'uqcPendResult_4'
-            ]
-          },
-          {
-            'ehr_list_index': '63',
-            'items': [
-              'uqcPendFlag_4'
             ]
           }
         ],
@@ -32527,19 +32551,14 @@ const DEFS = {
                 'form_label360',
                 'form_label361',
                 'form_label362',
-                'form_label363',
                 'uqcPendAnal_1',
                 'uqcPendResult_1',
-                'uqcPendFlag_1',
                 'uqcPendAnal_2',
                 'uqcPendResult_2',
-                'uqcPendFlag_2',
                 'uqcPendAnal_3',
                 'uqcPendResult_3',
-                'uqcPendFlag_3',
                 'uqcPendAnal_4',
-                'uqcPendResult_4',
-                'uqcPendFlag_4'
+                'uqcPendResult_4'
               ]
             }
           ],
@@ -32606,16 +32625,12 @@ const DEFS = {
             'uqcSomeQcUnacceptable': '',
             'uqcPendAnal_1': '',
             'uqcPendResult_1': '',
-            'uqcPendFlag_1': '',
             'uqcPendAnal_2': '',
             'uqcPendResult_2': '',
-            'uqcPendFlag_2': '',
             'uqcPendAnal_3': '',
             'uqcPendResult_3': '',
-            'uqcPendFlag_3': '',
             'uqcPendAnal_4': '',
-            'uqcPendResult_4': '',
-            'uqcPendFlag_4': ''
+            'uqcPendResult_4': ''
           }
         },
         'tableChildren': [
@@ -32676,16 +32691,12 @@ const DEFS = {
           'uqcSomeQcUnacceptable',
           'uqcPendAnal_1',
           'uqcPendResult_1',
-          'uqcPendFlag_1',
           'uqcPendAnal_2',
           'uqcPendResult_2',
-          'uqcPendFlag_2',
           'uqcPendAnal_3',
           'uqcPendResult_3',
-          'uqcPendFlag_3',
           'uqcPendAnal_4',
-          'uqcPendResult_4',
-          'uqcPendFlag_4'
+          'uqcPendResult_4'
         ],
         'hasRecHeader': true
       },
@@ -34199,7 +34210,7 @@ const DEFS = {
           'formKey': 'mlAccessioning',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group364',
+              'elementKey': 'ehr_group363',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34210,7 +34221,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group365',
+              'elementKey': 'ehr_group364',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34227,7 +34238,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group366',
+              'elementKey': 'ehr_group365',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
               'gChildren': [
@@ -34344,7 +34355,7 @@ const DEFS = {
           'formKey': 'mlChain',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group367',
+              'elementKey': 'ehr_group366',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34355,7 +34366,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group368',
+              'elementKey': 'ehr_group367',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34461,7 +34472,7 @@ const DEFS = {
           'formKey': 'mlTestStatus',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group369',
+              'elementKey': 'ehr_group368',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34472,7 +34483,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group370',
+              'elementKey': 'ehr_group369',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [

--- a/ehr-workspace/src/ehr-definitions/ehr-page-defs.js
+++ b/ehr-workspace/src/ehr-definitions/ehr-page-defs.js
@@ -12723,12 +12723,12 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
-        'elementKey': 'med_second_signature',
+        'elementKey': 'med_secondSig',
         'formIndex': '2',
         'inputType': 'checkbox',
-        'label': 'Second signature require',
+        'label': 'Second signature required',
         'tableColumn': '8',
-        'fqn': 'medicationOrders.med_second_signature'
+        'fqn': 'medicationOrders.med_secondSig'
       },
       {
         'elementKey': 'med_scheduled',
@@ -13214,7 +13214,7 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_second_signature'
+              'med_secondSig'
             ]
           },
           {
@@ -13322,7 +13322,7 @@ const DEFS = {
               'gChildren': [
                 'med_medication',
                 'med_dose',
-                'med_second_signature'
+                'med_secondSig'
               ]
             },
             {
@@ -13386,7 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
-            'med_second_signature': '',
+            'med_secondSig': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13416,7 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
-          'med_second_signature',
+          'med_secondSig',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13629,7 +13629,7 @@ const DEFS = {
         'formIndex': '2',
         'embedRef': 'medicationOrders.medicationOrdersTable',
         'inputType': 'ehr_embedded',
-        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id]',
+        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id mo_secondSig]',
         'fqn': 'medAdminRec.med_order_embedded'
       },
       {
@@ -13689,6 +13689,16 @@ const DEFS = {
         'fqn': 'medAdminRec.mo_id'
       },
       {
+        'elementKey': 'mo_secondSig',
+        'calculationType': 'embedValue(medicationOrders, medicationOrdersTable, med_secondSig)',
+        'formIndex': '2',
+        'formCss': 'grid-span-3-columns',
+        'inputType': 'calculatedBool',
+        'label': 'Second signature required',
+        'tableColumn': '6',
+        'fqn': 'medAdminRec.mo_secondSig'
+      },
+      {
         'elementKey': 'mar_status',
         'formIndex': '2',
         'inputType': 'select',
@@ -13711,7 +13721,7 @@ const DEFS = {
             'text': 'Skipped'
           }
         ],
-        'tableColumn': '6',
+        'tableColumn': '7',
         'fqn': 'medAdminRec.mar_status'
       },
       {
@@ -13719,7 +13729,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'tableColumn': '7',
+        'tableColumn': '8',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
@@ -13789,7 +13799,7 @@ const DEFS = {
             'text': 'Vaginal'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medAdminRec.mar_route'
       },
       {
@@ -13831,7 +13841,7 @@ const DEFS = {
             'text': 'Subcutaneous'
           }
         ],
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_injectionLocation'
       },
       {
@@ -13839,8 +13849,16 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'fqn': 'medAdminRec.mar_comments'
+      },
+      {
+        'elementKey': 'mar_secSigName',
+        'formIndex': '2',
+        'inputType': 'text',
+        'label': 'Second Signature',
+        'tableColumn': '12',
+        'fqn': 'medAdminRec.mar_secSigName'
       }
     ],
     'pageElements': {
@@ -14028,31 +14046,43 @@ const DEFS = {
           {
             'ehr_list_index': '6',
             'items': [
-              'mar_status'
+              'mo_secondSig'
             ]
           },
           {
             'ehr_list_index': '7',
             'items': [
-              'mar_dose'
+              'mar_status'
             ]
           },
           {
             'ehr_list_index': '8',
             'items': [
-              'mar_route'
+              'mar_dose'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'mar_injectionLocation'
+              'mar_route'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '11',
+            'items': [
               'mar_comments'
+            ]
+          },
+          {
+            'ehr_list_index': '12',
+            'items': [
+              'mar_secSigName'
             ]
           }
         ],
@@ -14094,7 +14124,8 @@ const DEFS = {
                 'mo_timing',
                 'mo_schedDay',
                 'mo_schedTime',
-                'mo_id'
+                'mo_id',
+                'mo_secondSig'
               ]
             },
             {
@@ -14124,6 +14155,15 @@ const DEFS = {
               'gChildren': [
                 'mar_comments'
               ]
+            },
+            {
+              'elementKey': 'mar_group_sec',
+              'dependentOn': 'visble:mo_secondSig',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '7',
+              'gChildren': [
+                'mar_secSigName'
+              ]
             }
           ],
           'ehr_data': {
@@ -14138,11 +14178,13 @@ const DEFS = {
             'mo_schedDay': '',
             'mo_schedTime': '',
             'mo_id': '',
+            'mo_secondSig': '',
             'mar_status': '',
             'mar_dose': '',
             'mar_route': '',
             'mar_injectionLocation': '',
-            'mar_comments': ''
+            'mar_comments': '',
+            'mar_secSigName': ''
           }
         },
         'tableChildren': [
@@ -14155,11 +14197,13 @@ const DEFS = {
           'mo_timing',
           'mo_schedDay',
           'mo_schedTime',
+          'mo_secondSig',
           'mar_status',
           'mar_dose',
           'mar_route',
           'mar_injectionLocation',
-          'mar_comments'
+          'mar_comments',
+          'mar_secSigName'
         ],
         'hasRecHeader': true
       }

--- a/ehr-workspace/src/ehr-definitions/ehr-types.js
+++ b/ehr-workspace/src/ehr-definitions/ehr-types.js
@@ -23,6 +23,7 @@ const EhrTypes = {
     checkbox: 'checkbox',
     boxcheckset: 'boxcheckset',
     select: 'select',
+    calculatedBool: 'calculatedBool',
     calculatedText: 'calculatedText',
     calculatedValue: 'calculatedValue',
     checkset: 'checkset',

--- a/ehr-workspace/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/ehr-workspace/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -65,7 +65,6 @@ export class MedOrder {
    * @returns {string}
    */
   medOrderSummary () {
-    console.log('mmos', this._e)
     const list = []
     list.push(this.medName)
     list.push(this.dose)

--- a/ehr-workspace/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/ehr-workspace/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -1,5 +1,6 @@
 import { MED_ORDERS_PAGE_KEY, MED_ORDERS_TABLE_KEY } from '../ehr-defs-grid'
 import { hourStringToHour } from './mar-model'
+import { makeHumanTableCell } from '../ehr-def-utils'
 
 export class MedOrders {
   constructor (ehrDataModel) {
@@ -26,12 +27,15 @@ export class MedOrders {
 export class MedOrder {
   constructor (eData) {
     this._e = {}
-    const {med_dose, medicationOrdersTable_id, med_instructions, med_injectionLocation,
+    let {med_dose, medicationOrdersTable_id, med_instructions, med_injectionLocation,
       med_scheduled,
       med_prnMaxDosage, med_medication,
       med_reason, med_route, med_timing,
       med_time1, med_time2, med_time3, med_time4, med_time5, med_time6
     } = eData
+    // translate the key data into human readable
+    med_route = makeHumanTableCell( 'medicationOrders', 'med_route', 'select', med_route)
+    med_injectionLocation = makeHumanTableCell( 'medicationOrders', 'med_injectionLocation', 'select', med_injectionLocation)
     this._e.day = eData['medicationOrdersTable_day']
     this._e.time = eData['medicationOrdersTable_time']
     this._e.name = eData['medicationOrdersTable_name']
@@ -61,12 +65,14 @@ export class MedOrder {
    * @returns {string}
    */
   medOrderSummary () {
+    console.log('mmos', this._e)
     const list = []
     list.push(this.medName)
     list.push(this.dose)
-    list.push(this.route)
     list.push(this.schedule)
-    return list.join(' ')
+    list.push(this.route)
+    list.push(this.location)
+    return list.join(', ')
   }
 
   /**

--- a/makeEhrV2/generated/ehrDefs/ehr-page-defs.js
+++ b/makeEhrV2/generated/ehrDefs/ehr-page-defs.js
@@ -12723,6 +12723,14 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
+        'elementKey': 'med_second_signature',
+        'formIndex': '2',
+        'inputType': 'checkbox',
+        'label': 'Second signature require',
+        'tableColumn': '8',
+        'fqn': 'medicationOrders.med_second_signature'
+      },
+      {
         'elementKey': 'med_scheduled',
         'formIndex': '2',
         'inputType': 'select',
@@ -12765,7 +12773,7 @@ const DEFS = {
             'text': 'Q1H'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medicationOrders.med_scheduled'
       },
       {
@@ -12773,7 +12781,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Max dosage',
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medicationOrders.med_prnMaxDosage'
       },
       {
@@ -12782,7 +12790,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 1',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time1'
       },
@@ -12792,7 +12800,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 2',
-        'tableColumn': '11',
+        'tableColumn': '12',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time2'
       },
@@ -12802,7 +12810,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 3',
-        'tableColumn': '12',
+        'tableColumn': '13',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time3'
       },
@@ -12812,7 +12820,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 4',
-        'tableColumn': '13',
+        'tableColumn': '14',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time4'
       },
@@ -12822,7 +12830,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 5',
-        'tableColumn': '14',
+        'tableColumn': '15',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time5'
       },
@@ -12832,7 +12840,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 6',
-        'tableColumn': '15',
+        'tableColumn': '16',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time6'
       },
@@ -12841,7 +12849,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Continuous description',
-        'tableColumn': '16',
+        'tableColumn': '17',
         'fqn': 'medicationOrders.med_continuous_description'
       },
       {
@@ -12850,7 +12858,7 @@ const DEFS = {
         'inputType': 'textarea',
         'label': 'Instructions',
         'suffix': 'medAdminRec',
-        'tableColumn': '17',
+        'tableColumn': '18',
         'tableLabel': 'Instructions',
         'fqn': 'medicationOrders.med_instructions',
         'suffixText': '<p>medAdminRec</p>',
@@ -13206,60 +13214,66 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_scheduled'
+              'med_second_signature'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'med_prnMaxDosage'
+              'med_scheduled'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
-              'med_time1'
+              'med_prnMaxDosage'
             ]
           },
           {
             'ehr_list_index': '11',
             'items': [
-              'med_time2'
+              'med_time1'
             ]
           },
           {
             'ehr_list_index': '12',
             'items': [
-              'med_time3'
+              'med_time2'
             ]
           },
           {
             'ehr_list_index': '13',
             'items': [
-              'med_time4'
+              'med_time3'
             ]
           },
           {
             'ehr_list_index': '14',
             'items': [
-              'med_time5'
+              'med_time4'
             ]
           },
           {
             'ehr_list_index': '15',
             'items': [
-              'med_time6'
+              'med_time5'
             ]
           },
           {
             'ehr_list_index': '16',
+            'items': [
+              'med_time6'
+            ]
+          },
+          {
+            'ehr_list_index': '17',
             'items': [
               'med_continuous_description'
             ]
           },
           {
             'label': 'Instructions',
-            'ehr_list_index': '17',
+            'ehr_list_index': '18',
             'items': [
               'med_instructions'
             ]
@@ -13307,7 +13321,8 @@ const DEFS = {
               'gIndex': '4',
               'gChildren': [
                 'med_medication',
-                'med_dose'
+                'med_dose',
+                'med_second_signature'
               ]
             },
             {
@@ -13371,6 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
+            'med_second_signature': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13400,6 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
+          'med_second_signature',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13676,7 +13693,6 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'select',
         'label': 'Status',
-        'mandatory': true,
         'options': [
           {
             'key': 'Administered',
@@ -13703,17 +13719,127 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'mandatory': true,
         'tableColumn': '7',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
+        'elementKey': 'mar_route',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Route',
+        'options': [
+          {
+            'key': 'oral',
+            'text': 'Oral'
+          },
+          {
+            'key': 'bucc',
+            'text': 'Buccal'
+          },
+          {
+            'key': 'cuta',
+            'text': 'Cutaneous'
+          },
+          {
+            'key': 'impl',
+            'text': 'Implant'
+          },
+          {
+            'key': 'inha',
+            'text': 'Inhalation'
+          },
+          {
+            'key': 'inje',
+            'text': 'Injection'
+          },
+          {
+            'key': 'intra',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'nasa',
+            'text': 'Nasal'
+          },
+          {
+            'key': 'nebu',
+            'text': 'Nebulization'
+          },
+          {
+            'key': 'ocul',
+            'text': 'Ocular'
+          },
+          {
+            'key': 'otic',
+            'text': 'Otic'
+          },
+          {
+            'key': 'rect',
+            'text': 'Rectal'
+          },
+          {
+            'key': 'subl',
+            'text': 'Sublingual'
+          },
+          {
+            'key': 'tran',
+            'text': 'Transdermal'
+          },
+          {
+            'key': 'vagi',
+            'text': 'Vaginal'
+          }
+        ],
+        'tableColumn': '8',
+        'fqn': 'medAdminRec.mar_route'
+      },
+      {
+        'elementKey': 'mar_injectionLocation',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Injection location',
+        'options': [
+          {
+            'key': 'arterial',
+            'text': 'Arterial'
+          },
+          {
+            'key': 'epidural',
+            'text': 'Epidural'
+          },
+          {
+            'key': 'intramuscular',
+            'text': 'Intramuscular'
+          },
+          {
+            'key': 'intraosseous',
+            'text': 'Intraosseous'
+          },
+          {
+            'key': 'intraperitoneal',
+            'text': 'Intraperitoneal'
+          },
+          {
+            'key': 'intrathecal',
+            'text': 'Intrathecal'
+          },
+          {
+            'key': 'intravenous',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'subcutaneous',
+            'text': 'Subcutaneous'
+          }
+        ],
+        'tableColumn': '9',
+        'fqn': 'medAdminRec.mar_injectionLocation'
+      },
+      {
         'elementKey': 'mar_comments',
         'formIndex': '2',
-        'formCss': 'grid-span-3-columns',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '8',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_comments'
       }
     ],
@@ -13914,6 +14040,18 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
+              'mar_route'
+            ]
+          },
+          {
+            'ehr_list_index': '9',
+            'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '10',
+            'items': [
               'mar_comments'
             ]
           }
@@ -13967,6 +14105,23 @@ const DEFS = {
               'gChildren': [
                 'mar_status',
                 'mar_dose',
+                'mar_route'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_inje',
+              'dependentOn': 'visble:mar_route=inje,intra',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '5',
+              'gChildren': [
+                'mar_injectionLocation'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_notes',
+              'formCss': 'grid-left-to-right-1',
+              'gIndex': '6',
+              'gChildren': [
                 'mar_comments'
               ]
             }
@@ -13985,6 +14140,8 @@ const DEFS = {
             'mo_id': '',
             'mar_status': '',
             'mar_dose': '',
+            'mar_route': '',
+            'mar_injectionLocation': '',
             'mar_comments': ''
           }
         },
@@ -14000,6 +14157,8 @@ const DEFS = {
           'mo_schedTime',
           'mar_status',
           'mar_dose',
+          'mar_route',
+          'mar_injectionLocation',
           'mar_comments'
         ],
         'hasRecHeader': true
@@ -14358,7 +14517,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group371',
+              'elementKey': 'ehr_group370',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14369,7 +14528,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group372',
+              'elementKey': 'ehr_group371',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -14578,7 +14737,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group373',
+              'elementKey': 'ehr_group372',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14589,7 +14748,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group374',
+              'elementKey': 'ehr_group373',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -14752,7 +14911,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group377',
+              'elementKey': 'ehr_group376',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14763,7 +14922,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group378',
+              'elementKey': 'ehr_group377',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -15986,7 +16145,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group383',
+              'elementKey': 'ehr_group382',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -15997,7 +16156,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group384',
+              'elementKey': 'ehr_group383',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -16130,7 +16289,7 @@ const DEFS = {
           'formKey': 'labResultHematology',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group385',
+              'elementKey': 'ehr_group384',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16141,7 +16300,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group386',
+              'elementKey': 'ehr_group385',
               'label': 'Hematology',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16155,7 +16314,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group387',
+              'elementKey': 'ehr_group386',
               'label': 'WBC Types',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16271,7 +16430,7 @@ const DEFS = {
           'formKey': 'labResultCoagulation',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group388',
+              'elementKey': 'ehr_group387',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16282,7 +16441,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group389',
+              'elementKey': 'ehr_group388',
               'label': 'Coagulation',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16531,7 +16690,7 @@ const DEFS = {
           'formKey': 'labResultGeneral',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group390',
+              'elementKey': 'ehr_group389',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16542,7 +16701,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group391',
+              'elementKey': 'ehr_group390',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16561,7 +16720,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group392',
+              'elementKey': 'ehr_group391',
               'label': 'Renal Profile',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16572,7 +16731,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group393',
+              'elementKey': 'ehr_group392',
               'label': 'Liver function',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -16588,7 +16747,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group394',
+              'elementKey': 'ehr_group393',
               'label': 'Blood gas tests',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '5',
@@ -16601,7 +16760,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group395',
+              'elementKey': 'ehr_group394',
               'label': 'Group and screen',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '6',
@@ -16739,7 +16898,7 @@ const DEFS = {
           'formKey': 'troponinTable',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group396',
+              'elementKey': 'ehr_group395',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16750,7 +16909,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group397',
+              'elementKey': 'ehr_group396',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -16975,7 +17134,7 @@ const DEFS = {
           'formKey': 'labResultUrine',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group398',
+              'elementKey': 'ehr_group397',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16986,7 +17145,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group399',
+              'elementKey': 'ehr_group398',
               'label': 'General',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16998,7 +17157,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group400',
+              'elementKey': 'ehr_group399',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -17024,7 +17183,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group401',
+              'elementKey': 'ehr_group400',
               'label': 'Microsopy',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -17232,7 +17391,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group379',
+              'elementKey': 'ehr_group378',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17243,7 +17402,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group380',
+              'elementKey': 'ehr_group379',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17397,7 +17556,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group381',
+              'elementKey': 'ehr_group380',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17408,7 +17567,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group382',
+              'elementKey': 'ehr_group381',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17589,7 +17748,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group402',
+            'elementKey': 'ehr_group401',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17691,7 +17850,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group403',
+            'elementKey': 'ehr_group402',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17915,7 +18074,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group404',
+              'elementKey': 'ehr_group403',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17926,7 +18085,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group405',
+              'elementKey': 'ehr_group404',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18124,7 +18283,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group406',
+              'elementKey': 'ehr_group405',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18135,7 +18294,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group407',
+              'elementKey': 'ehr_group406',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -18350,7 +18509,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group408',
+              'elementKey': 'ehr_group407',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18361,7 +18520,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group409',
+              'elementKey': 'ehr_group408',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18733,11 +18892,11 @@ const DEFS = {
         'fqn': 'testPage.textDateDate'
       },
       {
-        'elementKey': 'spacer415',
+        'elementKey': 'spacer414',
         'formIndex': '3',
         'inputType': 'spacer',
         'label': 'TextDate',
-        'fqn': 'testPage.spacer415'
+        'fqn': 'testPage.spacer414'
       },
       {
         'elementKey': 'name',
@@ -18763,7 +18922,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group410',
+            'elementKey': 'ehr_group409',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-1',
             'gIndex': '1',
@@ -18772,7 +18931,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group411',
+            'elementKey': 'ehr_group410',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '2',
@@ -18790,7 +18949,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group412',
+            'elementKey': 'ehr_group411',
             'label': 'Second group',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '3',
@@ -18868,7 +19027,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group413',
+              'elementKey': 'ehr_group412',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -18897,7 +19056,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group414',
+            'elementKey': 'ehr_group413',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
@@ -18908,7 +19067,7 @@ const DEFS = {
               'form2_time',
               'textDate',
               'textDateDate',
-              'spacer415',
+              'spacer414',
               'name',
               'place'
             ]
@@ -19259,13 +19418,13 @@ const DEFS = {
         'fqn': 'testTable.cd1Date'
       },
       {
-        'elementKey': 'spacer421',
+        'elementKey': 'spacer420',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 1',
         'tableColumn': '2',
         'tableLabel': 'Chk 1',
-        'fqn': 'testTable.spacer421'
+        'fqn': 'testTable.spacer420'
       },
       {
         'elementKey': 'cd2',
@@ -19287,13 +19446,13 @@ const DEFS = {
         'fqn': 'testTable.cd2Date'
       },
       {
-        'elementKey': 'spacer422',
+        'elementKey': 'spacer421',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 2',
         'tableColumn': '3',
         'tableLabel': 'Chk 2',
-        'fqn': 'testTable.spacer422'
+        'fqn': 'testTable.spacer421'
       },
       {
         'elementKey': 'td1',
@@ -19314,13 +19473,13 @@ const DEFS = {
         'fqn': 'testTable.td1Date'
       },
       {
-        'elementKey': 'spacer423',
+        'elementKey': 'spacer422',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'TextDate',
         'tableColumn': '4',
         'tableLabel': 'Txt 1',
-        'fqn': 'testTable.spacer423'
+        'fqn': 'testTable.spacer422'
       },
       {
         'elementKey': 'referralName',
@@ -19641,7 +19800,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group416',
+              'elementKey': 'ehr_group415',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -19658,7 +19817,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group417',
+              'elementKey': 'ehr_group416',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -19694,7 +19853,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group418',
+              'elementKey': 'ehr_group417',
               'formOption': '1',
               'formCss': 'full-width',
               'gIndex': '3',
@@ -19774,7 +19933,7 @@ const DEFS = {
             'items': [
               'cd1',
               'cd1Date',
-              'spacer421'
+              'spacer420'
             ]
           },
           {
@@ -19783,7 +19942,7 @@ const DEFS = {
             'items': [
               'cd2',
               'cd2Date',
-              'spacer422'
+              'spacer421'
             ]
           },
           {
@@ -19792,7 +19951,7 @@ const DEFS = {
             'items': [
               'td1',
               'td1Date',
-              'spacer423'
+              'spacer422'
             ]
           },
           {
@@ -19826,7 +19985,7 @@ const DEFS = {
           'formKey': 'stacked',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group419',
+              'elementKey': 'ehr_group418',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -19837,23 +19996,23 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group420',
+              'elementKey': 'ehr_group419',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
                 'cd1',
                 'cd1Date',
-                'spacer421',
+                'spacer420',
                 'cd2',
                 'cd2Date',
-                'spacer422',
+                'spacer421',
                 'td1',
                 'td1Date',
-                'spacer423'
+                'spacer422'
               ]
             },
             {
-              'elementKey': 'ehr_group424',
+              'elementKey': 'ehr_group423',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '3',
               'gChildren': [
@@ -19892,13 +20051,13 @@ const DEFS = {
           'stacked_time',
           'cd1',
           'cd1Date',
-          'spacer421',
+          'spacer420',
           'cd2',
           'cd2Date',
-          'spacer422',
+          'spacer421',
           'td1',
           'td1Date',
-          'spacer423',
+          'spacer422',
           'referralName',
           'referralProfession',
           'appointmentDate',
@@ -26608,7 +26767,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group375',
+              'elementKey': 'ehr_group374',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -26619,7 +26778,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group376',
+              'elementKey': 'ehr_group375',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -31770,13 +31929,6 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.form_label362'
       },
       {
-        'elementKey': 'form_label363',
-        'formIndex': '1',
-        'inputType': 'form_label',
-        'label': 'L, H, CH, Cl',
-        'fqn': 'medLabUrinalysis.form_label363'
-      },
-      {
         'elementKey': 'uqcPendAnal_1',
         'formIndex': '1',
         'inputType': 'text',
@@ -31791,150 +31943,46 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.uqcPendResult_1'
       },
       {
-        'elementKey': 'uqcPendFlag_1',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '54',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_1'
-      },
-      {
         'elementKey': 'uqcPendAnal_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '55',
+        'tableColumn': '54',
         'fqn': 'medLabUrinalysis.uqcPendAnal_2'
       },
       {
         'elementKey': 'uqcPendResult_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '56',
+        'tableColumn': '55',
         'fqn': 'medLabUrinalysis.uqcPendResult_2'
-      },
-      {
-        'elementKey': 'uqcPendFlag_2',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '57',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_2'
       },
       {
         'elementKey': 'uqcPendAnal_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '58',
+        'tableColumn': '56',
         'fqn': 'medLabUrinalysis.uqcPendAnal_3'
       },
       {
         'elementKey': 'uqcPendResult_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '59',
+        'tableColumn': '57',
         'fqn': 'medLabUrinalysis.uqcPendResult_3'
-      },
-      {
-        'elementKey': 'uqcPendFlag_3',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '60',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_3'
       },
       {
         'elementKey': 'uqcPendAnal_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '61',
+        'tableColumn': '58',
         'fqn': 'medLabUrinalysis.uqcPendAnal_4'
       },
       {
         'elementKey': 'uqcPendResult_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '62',
+        'tableColumn': '59',
         'fqn': 'medLabUrinalysis.uqcPendResult_4'
-      },
-      {
-        'elementKey': 'uqcPendFlag_4',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '63',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_4'
       }
     ],
     'pageElements': {
@@ -32325,61 +32373,37 @@ const DEFS = {
           {
             'ehr_list_index': '54',
             'items': [
-              'uqcPendFlag_1'
+              'uqcPendAnal_2'
             ]
           },
           {
             'ehr_list_index': '55',
             'items': [
-              'uqcPendAnal_2'
+              'uqcPendResult_2'
             ]
           },
           {
             'ehr_list_index': '56',
             'items': [
-              'uqcPendResult_2'
+              'uqcPendAnal_3'
             ]
           },
           {
             'ehr_list_index': '57',
             'items': [
-              'uqcPendFlag_2'
+              'uqcPendResult_3'
             ]
           },
           {
             'ehr_list_index': '58',
             'items': [
-              'uqcPendAnal_3'
+              'uqcPendAnal_4'
             ]
           },
           {
             'ehr_list_index': '59',
             'items': [
-              'uqcPendResult_3'
-            ]
-          },
-          {
-            'ehr_list_index': '60',
-            'items': [
-              'uqcPendFlag_3'
-            ]
-          },
-          {
-            'ehr_list_index': '61',
-            'items': [
-              'uqcPendAnal_4'
-            ]
-          },
-          {
-            'ehr_list_index': '62',
-            'items': [
               'uqcPendResult_4'
-            ]
-          },
-          {
-            'ehr_list_index': '63',
-            'items': [
-              'uqcPendFlag_4'
             ]
           }
         ],
@@ -32527,19 +32551,14 @@ const DEFS = {
                 'form_label360',
                 'form_label361',
                 'form_label362',
-                'form_label363',
                 'uqcPendAnal_1',
                 'uqcPendResult_1',
-                'uqcPendFlag_1',
                 'uqcPendAnal_2',
                 'uqcPendResult_2',
-                'uqcPendFlag_2',
                 'uqcPendAnal_3',
                 'uqcPendResult_3',
-                'uqcPendFlag_3',
                 'uqcPendAnal_4',
-                'uqcPendResult_4',
-                'uqcPendFlag_4'
+                'uqcPendResult_4'
               ]
             }
           ],
@@ -32606,16 +32625,12 @@ const DEFS = {
             'uqcSomeQcUnacceptable': '',
             'uqcPendAnal_1': '',
             'uqcPendResult_1': '',
-            'uqcPendFlag_1': '',
             'uqcPendAnal_2': '',
             'uqcPendResult_2': '',
-            'uqcPendFlag_2': '',
             'uqcPendAnal_3': '',
             'uqcPendResult_3': '',
-            'uqcPendFlag_3': '',
             'uqcPendAnal_4': '',
-            'uqcPendResult_4': '',
-            'uqcPendFlag_4': ''
+            'uqcPendResult_4': ''
           }
         },
         'tableChildren': [
@@ -32676,16 +32691,12 @@ const DEFS = {
           'uqcSomeQcUnacceptable',
           'uqcPendAnal_1',
           'uqcPendResult_1',
-          'uqcPendFlag_1',
           'uqcPendAnal_2',
           'uqcPendResult_2',
-          'uqcPendFlag_2',
           'uqcPendAnal_3',
           'uqcPendResult_3',
-          'uqcPendFlag_3',
           'uqcPendAnal_4',
-          'uqcPendResult_4',
-          'uqcPendFlag_4'
+          'uqcPendResult_4'
         ],
         'hasRecHeader': true
       },
@@ -34199,7 +34210,7 @@ const DEFS = {
           'formKey': 'mlAccessioning',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group364',
+              'elementKey': 'ehr_group363',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34210,7 +34221,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group365',
+              'elementKey': 'ehr_group364',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34227,7 +34238,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group366',
+              'elementKey': 'ehr_group365',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
               'gChildren': [
@@ -34344,7 +34355,7 @@ const DEFS = {
           'formKey': 'mlChain',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group367',
+              'elementKey': 'ehr_group366',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34355,7 +34366,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group368',
+              'elementKey': 'ehr_group367',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34461,7 +34472,7 @@ const DEFS = {
           'formKey': 'mlTestStatus',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group369',
+              'elementKey': 'ehr_group368',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34472,7 +34483,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group370',
+              'elementKey': 'ehr_group369',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [

--- a/makeEhrV2/generated/ehrDefs/ehr-page-defs.js
+++ b/makeEhrV2/generated/ehrDefs/ehr-page-defs.js
@@ -12723,12 +12723,12 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
-        'elementKey': 'med_second_signature',
+        'elementKey': 'med_secondSig',
         'formIndex': '2',
         'inputType': 'checkbox',
-        'label': 'Second signature require',
+        'label': 'Second signature required',
         'tableColumn': '8',
-        'fqn': 'medicationOrders.med_second_signature'
+        'fqn': 'medicationOrders.med_secondSig'
       },
       {
         'elementKey': 'med_scheduled',
@@ -13214,7 +13214,7 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_second_signature'
+              'med_secondSig'
             ]
           },
           {
@@ -13322,7 +13322,7 @@ const DEFS = {
               'gChildren': [
                 'med_medication',
                 'med_dose',
-                'med_second_signature'
+                'med_secondSig'
               ]
             },
             {
@@ -13386,7 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
-            'med_second_signature': '',
+            'med_secondSig': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13416,7 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
-          'med_second_signature',
+          'med_secondSig',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13629,7 +13629,7 @@ const DEFS = {
         'formIndex': '2',
         'embedRef': 'medicationOrders.medicationOrdersTable',
         'inputType': 'ehr_embedded',
-        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id]',
+        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id mo_secondSig]',
         'fqn': 'medAdminRec.med_order_embedded'
       },
       {
@@ -13689,6 +13689,16 @@ const DEFS = {
         'fqn': 'medAdminRec.mo_id'
       },
       {
+        'elementKey': 'mo_secondSig',
+        'calculationType': 'embedValue(medicationOrders, medicationOrdersTable, med_secondSig)',
+        'formIndex': '2',
+        'formCss': 'grid-span-3-columns',
+        'inputType': 'calculatedBool',
+        'label': 'Second signature required',
+        'tableColumn': '6',
+        'fqn': 'medAdminRec.mo_secondSig'
+      },
+      {
         'elementKey': 'mar_status',
         'formIndex': '2',
         'inputType': 'select',
@@ -13711,7 +13721,7 @@ const DEFS = {
             'text': 'Skipped'
           }
         ],
-        'tableColumn': '6',
+        'tableColumn': '7',
         'fqn': 'medAdminRec.mar_status'
       },
       {
@@ -13719,7 +13729,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'tableColumn': '7',
+        'tableColumn': '8',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
@@ -13789,7 +13799,7 @@ const DEFS = {
             'text': 'Vaginal'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medAdminRec.mar_route'
       },
       {
@@ -13831,7 +13841,7 @@ const DEFS = {
             'text': 'Subcutaneous'
           }
         ],
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_injectionLocation'
       },
       {
@@ -13839,8 +13849,16 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'fqn': 'medAdminRec.mar_comments'
+      },
+      {
+        'elementKey': 'mar_secSigName',
+        'formIndex': '2',
+        'inputType': 'text',
+        'label': 'Second Signature',
+        'tableColumn': '12',
+        'fqn': 'medAdminRec.mar_secSigName'
       }
     ],
     'pageElements': {
@@ -14028,31 +14046,43 @@ const DEFS = {
           {
             'ehr_list_index': '6',
             'items': [
-              'mar_status'
+              'mo_secondSig'
             ]
           },
           {
             'ehr_list_index': '7',
             'items': [
-              'mar_dose'
+              'mar_status'
             ]
           },
           {
             'ehr_list_index': '8',
             'items': [
-              'mar_route'
+              'mar_dose'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'mar_injectionLocation'
+              'mar_route'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '11',
+            'items': [
               'mar_comments'
+            ]
+          },
+          {
+            'ehr_list_index': '12',
+            'items': [
+              'mar_secSigName'
             ]
           }
         ],
@@ -14094,7 +14124,8 @@ const DEFS = {
                 'mo_timing',
                 'mo_schedDay',
                 'mo_schedTime',
-                'mo_id'
+                'mo_id',
+                'mo_secondSig'
               ]
             },
             {
@@ -14124,6 +14155,15 @@ const DEFS = {
               'gChildren': [
                 'mar_comments'
               ]
+            },
+            {
+              'elementKey': 'mar_group_sec',
+              'dependentOn': 'visble:mo_secondSig',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '7',
+              'gChildren': [
+                'mar_secSigName'
+              ]
             }
           ],
           'ehr_data': {
@@ -14138,11 +14178,13 @@ const DEFS = {
             'mo_schedDay': '',
             'mo_schedTime': '',
             'mo_id': '',
+            'mo_secondSig': '',
             'mar_status': '',
             'mar_dose': '',
             'mar_route': '',
             'mar_injectionLocation': '',
-            'mar_comments': ''
+            'mar_comments': '',
+            'mar_secSigName': ''
           }
         },
         'tableChildren': [
@@ -14155,11 +14197,13 @@ const DEFS = {
           'mo_timing',
           'mo_schedDay',
           'mo_schedTime',
+          'mo_secondSig',
           'mar_status',
           'mar_dose',
           'mar_route',
           'mar_injectionLocation',
-          'mar_comments'
+          'mar_comments',
+          'mar_secSigName'
         ],
         'hasRecHeader': true
       }

--- a/makeEhrV2/hashMapFile.json
+++ b/makeEhrV2/hashMapFile.json
@@ -3,7 +3,7 @@
   "current-visit-1": "c5f2b960d7fb5362a1e1603f08081099",
   "current-visit-2": "c42d28300fc1fa85ce6366e44031bb07",
   "current-visit-3": "ceaa344e074c1938e5d4dd701259f0bd",
-  "current-mar": "95d39f92f1ef1b149f531fac34bcfcae",
+  "current-mar": "9d64bfda4ea5c9acc9f6e6be3593e269",
   "patient-chart": "b51669bc27918629724746e88fbd74da",
   "patient-chart-2": "591b777fcfb727a86cc4718f2233e394",
   "external-resources": "cb379ada4eaad6d2c741a14789f71ace",

--- a/makeEhrV2/hashMapFile.json
+++ b/makeEhrV2/hashMapFile.json
@@ -3,11 +3,11 @@
   "current-visit-1": "c5f2b960d7fb5362a1e1603f08081099",
   "current-visit-2": "c42d28300fc1fa85ce6366e44031bb07",
   "current-visit-3": "ceaa344e074c1938e5d4dd701259f0bd",
-  "current-mar": "a735f466a79a9508fd509a596ae3dcce",
+  "current-mar": "95d39f92f1ef1b149f531fac34bcfcae",
   "patient-chart": "b51669bc27918629724746e88fbd74da",
   "patient-chart-2": "591b777fcfb727a86cc4718f2233e394",
   "external-resources": "cb379ada4eaad6d2c741a14789f71ace",
   "test-page": "ec345feb4d4e5b724b31fa07df579693",
-  "med-lab": "dbbd72e14fea2565b41164704cb0d41f",
+  "med-lab": "d425e999d1b086bb2da98cf10bf07efb",
   "current-visit-4": "84fccff6e5121202192df82b9d2282c7"
 }

--- a/makeEhrV2/raw_data/current-mar.txt
+++ b/makeEhrV2/raw_data/current-mar.txt
@@ -86,7 +86,7 @@ subcutaneous:=Subcutaneous}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCe
 {inputType: ehr_group}	eCell	eCell	{Comments: Non-continuous}	{elementKey: med_group_non_continuous}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: lookahead}	eCell	{Label: Medication}	eCell	{elementKey: med_medication}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	{tableLabel: Medication}	{tableColumn: 6}	eCell	eCell	eCell	eCell	eCell	eCell	{Mandatory: TRUE}	eCell	eCell	eCell	{helperText: For your reference, here is a link to the EdEHR medications table. <a href="/assets/static-databases/drug.txt" target="_blank">Medications</a>. Source is <a href="https://www.canada.ca/en/health-canada/services/drugs-health-products/drug-products/drug-product-database/what-data-extract-drug-product-database.html" target="_blank">https://www.canada.ca/en/health-canada/services/drugs-health-products/drug-products/drug-product-database/what-data-extract-drug-product-database.html</a>}	eCell	eCell	eCell	eCell	eCell
 {inputType: text}	eCell	{Label: Dose}	eCell	{elementKey: med_dose}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 7}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: checkbox}	eCell	{Label: Second signature require}	{Comments: ,}	{elementKey: med_second_signature}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: checkbox}	eCell	{Label: Second signature required}	eCell	{elementKey: med_secondSig}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	{Comments: with times}	{elementKey: med_group_with_times}	{pN: 25}	{fN: 2}	{gN: 5}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:med_timing=prn,sched,set}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: select}	eCell	{Label: Scheduled}	eCell	{elementKey: med_scheduled}	{pN: 25}	{fN: 2}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 9}	eCell	eCell	eCell	eCell	"{Options: BID
 TID
@@ -132,7 +132,7 @@ Skipped}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	eCell	{pN: 26}	{fN: 2}	{gN: 1}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: record_header}	eCell	eCell	eCell	eCell	{pN: 26}	{fN: 2}	{gN: 1}	{sgN: }	eCell	eCell	eCell	{tableColumn: 1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	{Label: Med order ref}	eCell	eCell	{pN: 26}	{fN: 2}	{gN: 2}	{sgN: }	{formCss: grid-left-to-right-3}	{formOption: hideGroup}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: ehr_embedded}	eCell	eCell	eCell	{elementKey: med_order_embedded}	{pN: 26}	{fN: 2}	{gN: 2}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{passToFunction: [mo_medOrder mo_timing mo_medInstructions mo_id]}	eCell	eCell	eCell	{embedRef: medicationOrders.medicationOrdersTable}
+{inputType: ehr_embedded}	eCell	eCell	eCell	{elementKey: med_order_embedded}	{pN: 26}	{fN: 2}	{gN: 2}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{passToFunction: [mo_medOrder mo_timing mo_medInstructions mo_id mo_secondSig]}	eCell	eCell	eCell	{embedRef: medicationOrders.medicationOrdersTable}
 {inputType: ehr_group}	eCell	{Label: Med order}	eCell	eCell	{pN: 26}	{fN: 2}	{gN: 3}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: calculatedValue}	eCell	{Label: Med order}	eCell	{elementKey: mo_medOrder}	{pN: 26}	{fN: 2}	{gN: 3}	{sgN: }	{formCss: grid-span-3-columns}	eCell	eCell	{tableColumn: 2}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{calculationType: medOrderSummary(medicationOrders,medicationOrdersTable)}	eCell	eCell	eCell
 {inputType: calculatedValue}	eCell	{Label: Instructions}	eCell	{elementKey: mo_medInstructions}	{pN: 26}	{fN: 2}	{gN: 3}	{sgN: }	{formCss: grid-span-3-columns}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{calculationType: embedValue(medicationOrders, medicationOrdersTable, med_instructions)}	eCell	eCell	eCell
@@ -140,13 +140,14 @@ Skipped}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: visitDay}	eCell	{Label: Scheduled day}	eCell	{elementKey: mo_schedDay}	{pN: 26}	{fN: 2}	{gN: 3}	{sgN: }	eCell	{formOption: elementViewOnly}	eCell	{tableColumn: 4}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{calculationType: embedValue(medicationOrders, medicationOrdersTable, med_instructions)}	eCell	eCell	eCell
 {inputType: visitTime}	eCell	{Label: Scheduled time}	eCell	{elementKey: mo_schedTime}	{pN: 26}	{fN: 2}	{gN: 3}	{sgN: }	eCell	{formOption: elementViewOnly}	eCell	{tableColumn: 5}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: calculatedValue}	eCell	{Label: Med Order Id}	eCell	{elementKey: mo_id}	{pN: 26}	{fN: 2}	{gN: 3}	{sgN: }	eCell	{formOption: hideElement}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{calculationType: embedValue(medicationOrders, medicationOrdersTable, medicationOrdersTable_id)}	eCell	eCell	eCell
+{inputType: calculatedBool}	eCell	{Label: Second signature required}	eCell	{elementKey: mo_secondSig}	{pN: 26}	{fN: 2}	{gN: 3}	{sgN: }	{formCss: grid-span-3-columns}	eCell	eCell	{tableColumn: 6}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{calculationType: embedValue(medicationOrders, medicationOrdersTable, med_secondSig)}	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	{Label: Med admin}	eCell	eCell	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: select}	eCell	{Label: Status}	eCell	{elementKey: mar_status}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 6}	eCell	eCell	eCell	eCell	"{Options: Administered
+{inputType: select}	eCell	{Label: Status}	eCell	{elementKey: mar_status}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 7}	eCell	eCell	eCell	eCell	"{Options: Administered
 Refused
 Missed
 Skipped}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Dose given}	eCell	{elementKey: mar_dose}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 7}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: select}	eCell	{Label: Route}	eCell	{elementKey: mar_route}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	"{Options: oral:=Oral
+{inputType: text}	eCell	{Label: Dose given}	eCell	{elementKey: mar_dose}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: select}	eCell	{Label: Route}	eCell	{elementKey: mar_route}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 9}	eCell	eCell	eCell	eCell	"{Options: oral:=Oral
 bucc:=Buccal
 cuta:=Cutaneous
 impl:=Implant
@@ -162,7 +163,7 @@ subl:=Sublingual
 tran:=Transdermal
 vagi:=Vaginal}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{elementKey: mar_group_inje}	{pN: 26}	{fN: 2}	{gN: 5}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:mar_route=inje,intra}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: select}	eCell	{Label: Injection location}	eCell	{elementKey: mar_injectionLocation}	{pN: 26}	{fN: 2}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 9}	eCell	eCell	eCell	eCell	"{Options: arterial:=Arterial
+{inputType: select}	eCell	{Label: Injection location}	eCell	{elementKey: mar_injectionLocation}	{pN: 26}	{fN: 2}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	eCell	eCell	"{Options: arterial:=Arterial
 epidural:=Epidural
 intramuscular:=Intramuscular
 intraosseous:=Intraosseous
@@ -171,4 +172,6 @@ intrathecal:=Intrathecal
 intravenous:=Intravenous
 subcutaneous:=Subcutaneous}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{elementKey: mar_group_notes}	{pN: 26}	{fN: 2}	{gN: 6}	{sgN: }	{formCss: grid-left-to-right-1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: textarea}	eCell	{Label: Comments}	eCell	{elementKey: mar_comments}	{pN: 26}	{fN: 2}	{gN: 6}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: textarea}	eCell	{Label: Comments}	eCell	{elementKey: mar_comments}	{pN: 26}	{fN: 2}	{gN: 6}	{sgN: }	eCell	eCell	eCell	{tableColumn: 11}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{elementKey: mar_group_sec}	{pN: 26}	{fN: 2}	{gN: 7}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:mo_secondSig}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Second Signature}	eCell	{elementKey: mar_secSigName}	{pN: 26}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 12}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell

--- a/makeEhrV2/raw_data/current-mar.txt
+++ b/makeEhrV2/raw_data/current-mar.txt
@@ -86,8 +86,9 @@ subcutaneous:=Subcutaneous}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCe
 {inputType: ehr_group}	eCell	eCell	{Comments: Non-continuous}	{elementKey: med_group_non_continuous}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: lookahead}	eCell	{Label: Medication}	eCell	{elementKey: med_medication}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	{tableLabel: Medication}	{tableColumn: 6}	eCell	eCell	eCell	eCell	eCell	eCell	{Mandatory: TRUE}	eCell	eCell	eCell	{helperText: For your reference, here is a link to the EdEHR medications table. <a href="/assets/static-databases/drug.txt" target="_blank">Medications</a>. Source is <a href="https://www.canada.ca/en/health-canada/services/drugs-health-products/drug-products/drug-product-database/what-data-extract-drug-product-database.html" target="_blank">https://www.canada.ca/en/health-canada/services/drugs-health-products/drug-products/drug-product-database/what-data-extract-drug-product-database.html</a>}	eCell	eCell	eCell	eCell	eCell
 {inputType: text}	eCell	{Label: Dose}	eCell	{elementKey: med_dose}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 7}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: checkbox}	eCell	{Label: Second signature require}	{Comments: ,}	{elementKey: med_second_signature}	{pN: 25}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	{Comments: with times}	{elementKey: med_group_with_times}	{pN: 25}	{fN: 2}	{gN: 5}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:med_timing=prn,sched,set}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: select}	eCell	{Label: Scheduled}	eCell	{elementKey: med_scheduled}	{pN: 25}	{fN: 2}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	"{Options: BID
+{inputType: select}	eCell	{Label: Scheduled}	eCell	{elementKey: med_scheduled}	{pN: 25}	{fN: 2}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 9}	eCell	eCell	eCell	eCell	"{Options: BID
 TID
 QID
 Q12H
@@ -97,18 +98,18 @@ Q4H
 Q2H
 Q1H}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	{Comments: with times}	{elementKey: med_prn_group}	{pN: 25}	{fN: 2}	{gN: 6}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:med_timing=prn}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Max dosage}	eCell	{elementKey: med_prnMaxDosage}	{pN: 25}	{fN: 2}	{gN: 6}	{sgN: }	eCell	eCell	eCell	{tableColumn: 9}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Max dosage}	eCell	{elementKey: med_prnMaxDosage}	{pN: 25}	{fN: 2}	{gN: 6}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{elementKey: med_group_times}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:med_timing=prn,sched,set}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Time 1}	eCell	{elementKey: med_time1}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Time 2}	eCell	{elementKey: med_time2}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 11}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Time 3}	eCell	{elementKey: med_time3}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 12}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Time 4}	eCell	{elementKey: med_time4}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 13}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Time 5}	eCell	{elementKey: med_time5}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 14}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Time 6}	eCell	{elementKey: med_time6}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 15}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Time 1}	eCell	{elementKey: med_time1}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 11}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Time 2}	eCell	{elementKey: med_time2}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 12}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Time 3}	eCell	{elementKey: med_time3}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 13}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Time 4}	eCell	{elementKey: med_time4}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 14}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Time 5}	eCell	{elementKey: med_time5}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 15}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Time 6}	eCell	{elementKey: med_time6}	{pN: 25}	{fN: 2}	{gN: 7}	{sgN: }	eCell	eCell	eCell	{tableColumn: 16}	eCell	eCell	{dependentOn: onChange:med_scheduled}	eCell	eCell	eCell	eCell	{Validation: time24}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{elementKey: med_group_infusion_c1}	{pN: 25}	{fN: 2}	{gN: 8}	{sgN: }	{formCss: grid-left-to-right-1}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:med_timing=cont}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: textarea}	eCell	{Label: Continuous description}	eCell	{elementKey: med_continuous_description}	{pN: 25}	{fN: 2}	{gN: 8}	{sgN: }	eCell	eCell	eCell	{tableColumn: 16}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: textarea}	eCell	{Label: Continuous description}	eCell	{elementKey: med_continuous_description}	{pN: 25}	{fN: 2}	{gN: 8}	{sgN: }	eCell	eCell	eCell	{tableColumn: 17}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	{elementKey: med_group_notes}	{pN: 25}	{fN: 2}	{gN: 9}	{sgN: }	{formCss: grid-left-to-right-1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: textarea}	eCell	{Label: Instructions}	eCell	{elementKey: med_instructions}	{pN: 25}	{fN: 2}	{gN: 9}	{sgN: }	eCell	eCell	{tableLabel: Instructions}	{tableColumn: 17}	eCell	eCell	eCell	eCell	eCell	{Suffix: medAdminRec}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: textarea}	eCell	{Label: Instructions}	eCell	{elementKey: med_instructions}	{pN: 25}	{fN: 2}	{gN: 9}	{sgN: }	eCell	eCell	{tableLabel: Instructions}	{tableColumn: 18}	eCell	eCell	eCell	eCell	eCell	{Suffix: medAdminRec}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: page}	{pRef: 31}	{Label: Medication administration records}	eCell	{elementKey: medAdminRec}	{pN: 26}	{fN: }	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: table_form}	eCell	{Label: Medication administration records}	eCell	{elementKey: table}	{pN: 26}	{fN: 1}	{gN: }	{sgN: }	eCell	eCell	{tableLabel: This data is for an older version and it needs to be updated. Contact EdEHR for assistance.}	eCell	eCell	{addButtonText: Administered}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	eCell	{pN: 26}	{fN: 1}	{gN: 1}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
@@ -143,6 +144,31 @@ Skipped}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: select}	eCell	{Label: Status}	eCell	{elementKey: mar_status}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 6}	eCell	eCell	eCell	eCell	"{Options: Administered
 Refused
 Missed
-Skipped}"	eCell	{Mandatory: TRUE}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	{Label: Dose given}	eCell	{elementKey: mar_dose}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 7}	eCell	eCell	eCell	eCell	eCell	eCell	{Mandatory: TRUE}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: textarea}	eCell	{Label: Comments}	eCell	{elementKey: mar_comments}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	{formCss: grid-span-3-columns}	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+Skipped}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	{Label: Dose given}	eCell	{elementKey: mar_dose}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 7}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: select}	eCell	{Label: Route}	eCell	{elementKey: mar_route}	{pN: 26}	{fN: 2}	{gN: 4}	{sgN: }	eCell	eCell	eCell	{tableColumn: 8}	eCell	eCell	eCell	eCell	"{Options: oral:=Oral
+bucc:=Buccal
+cuta:=Cutaneous
+impl:=Implant
+inha:=Inhalation
+inje:=Injection
+intra:=Intravenous
+nasa:=Nasal
+nebu:=Nebulization
+ocul:=Ocular
+otic:=Otic
+rect:=Rectal
+subl:=Sublingual
+tran:=Transdermal
+vagi:=Vaginal}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{elementKey: mar_group_inje}	{pN: 26}	{fN: 2}	{gN: 5}	{sgN: }	{formCss: grid-left-to-right-3}	eCell	eCell	eCell	eCell	eCell	{dependentOn: visble:mar_route=inje,intra}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: select}	eCell	{Label: Injection location}	eCell	{elementKey: mar_injectionLocation}	{pN: 26}	{fN: 2}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 9}	eCell	eCell	eCell	eCell	"{Options: arterial:=Arterial
+epidural:=Epidural
+intramuscular:=Intramuscular
+intraosseous:=Intraosseous
+intraperitoneal:=Intraperitoneal
+intrathecal:=Intrathecal
+intravenous:=Intravenous
+subcutaneous:=Subcutaneous}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: ehr_group}	eCell	eCell	eCell	{elementKey: mar_group_notes}	{pN: 26}	{fN: 2}	{gN: 6}	{sgN: }	{formCss: grid-left-to-right-1}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: textarea}	eCell	{Label: Comments}	eCell	{elementKey: mar_comments}	{pN: 26}	{fN: 2}	{gN: 6}	{sgN: }	eCell	eCell	eCell	{tableColumn: 10}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell

--- a/makeEhrV2/raw_data/med-lab.txt
+++ b/makeEhrV2/raw_data/med-lab.txt
@@ -855,31 +855,14 @@ clinitek:= >= 70 Leu//μL}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	{calculati
 {inputType: form_label}	eCell	{Label: Reporting “pending” to patient care staff indicates that results are unavailable and awaiting validation by the technologist before results are released.}	eCell	eCell	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	{formCss: grid-span-3-columns}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: form_label}	eCell	{Label: Pending analyte}	eCell	eCell	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: form_label}	eCell	{Label: Pending result (include units)}	eCell	eCell	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: form_label}	eCell	{Label: L, H, CH, Cl}	eCell	eCell	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendAnal_1}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 52}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendResult_1}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 53}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: radioset}	eCell	eCell	eCell	{elementKey: uqcPendFlag_1}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	{formCss: chem-results-lhclch}	eCell	eCell	{tableColumn: 54}	eCell	eCell	eCell	eCell	"{Options: L
-H
-CL
-CH}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendAnal_2}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 55}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendResult_2}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 56}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: radioset}	eCell	eCell	eCell	{elementKey: uqcPendFlag_2}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	{formCss: chem-results-lhclch}	eCell	eCell	{tableColumn: 57}	eCell	eCell	eCell	eCell	"{Options: L
-H
-CL
-CH}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendAnal_3}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 58}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendResult_3}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 59}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: radioset}	eCell	eCell	eCell	{elementKey: uqcPendFlag_3}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	{formCss: chem-results-lhclch}	eCell	eCell	{tableColumn: 60}	eCell	eCell	eCell	eCell	"{Options: L
-H
-CL
-CH}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendAnal_4}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 61}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendResult_4}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 62}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
-{inputType: radioset}	eCell	eCell	eCell	{elementKey: uqcPendFlag_4}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	{formCss: chem-results-lhclch}	eCell	eCell	{tableColumn: 63}	eCell	eCell	eCell	eCell	"{Options: L
-H
-CL
-CH}"	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendAnal_2}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 54}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendResult_2}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 55}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendAnal_3}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 56}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendResult_3}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 57}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendAnal_4}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 58}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
+{inputType: text}	eCell	eCell	eCell	{elementKey: uqcPendResult_4}	{pN: 46}	{fN: 1}	{gN: 5}	{sgN: }	eCell	eCell	eCell	{tableColumn: 59}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: page}	{pRef: 58}	{Label: Med Lab Accessioning}	eCell	{elementKey: medLabAccession}	{pN: 50}	{fN: }	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: table_form}	eCell	{Label: Accessioning}	eCell	{elementKey: mlAccessioning}	{pN: 50}	{fN: 1}	{gN: }	{sgN: }	eCell	eCell	eCell	eCell	eCell	{addButtonText: Create an accessioning record}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell
 {inputType: ehr_group}	eCell	eCell	eCell	eCell	{pN: 50}	{fN: 1}	{gN: 1}	{sgN: }	{formCss: record-header}	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell	eCell

--- a/server/src/ehr-definitions/ehr-page-defs.js
+++ b/server/src/ehr-definitions/ehr-page-defs.js
@@ -12723,6 +12723,14 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
+        'elementKey': 'med_second_signature',
+        'formIndex': '2',
+        'inputType': 'checkbox',
+        'label': 'Second signature require',
+        'tableColumn': '8',
+        'fqn': 'medicationOrders.med_second_signature'
+      },
+      {
         'elementKey': 'med_scheduled',
         'formIndex': '2',
         'inputType': 'select',
@@ -12765,7 +12773,7 @@ const DEFS = {
             'text': 'Q1H'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medicationOrders.med_scheduled'
       },
       {
@@ -12773,7 +12781,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Max dosage',
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medicationOrders.med_prnMaxDosage'
       },
       {
@@ -12782,7 +12790,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 1',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time1'
       },
@@ -12792,7 +12800,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 2',
-        'tableColumn': '11',
+        'tableColumn': '12',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time2'
       },
@@ -12802,7 +12810,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 3',
-        'tableColumn': '12',
+        'tableColumn': '13',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time3'
       },
@@ -12812,7 +12820,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 4',
-        'tableColumn': '13',
+        'tableColumn': '14',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time4'
       },
@@ -12822,7 +12830,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 5',
-        'tableColumn': '14',
+        'tableColumn': '15',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time5'
       },
@@ -12832,7 +12840,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Time 6',
-        'tableColumn': '15',
+        'tableColumn': '16',
         'validation': 'time24',
         'fqn': 'medicationOrders.med_time6'
       },
@@ -12841,7 +12849,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Continuous description',
-        'tableColumn': '16',
+        'tableColumn': '17',
         'fqn': 'medicationOrders.med_continuous_description'
       },
       {
@@ -12850,7 +12858,7 @@ const DEFS = {
         'inputType': 'textarea',
         'label': 'Instructions',
         'suffix': 'medAdminRec',
-        'tableColumn': '17',
+        'tableColumn': '18',
         'tableLabel': 'Instructions',
         'fqn': 'medicationOrders.med_instructions',
         'suffixText': '<p>medAdminRec</p>',
@@ -13206,60 +13214,66 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_scheduled'
+              'med_second_signature'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'med_prnMaxDosage'
+              'med_scheduled'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
-              'med_time1'
+              'med_prnMaxDosage'
             ]
           },
           {
             'ehr_list_index': '11',
             'items': [
-              'med_time2'
+              'med_time1'
             ]
           },
           {
             'ehr_list_index': '12',
             'items': [
-              'med_time3'
+              'med_time2'
             ]
           },
           {
             'ehr_list_index': '13',
             'items': [
-              'med_time4'
+              'med_time3'
             ]
           },
           {
             'ehr_list_index': '14',
             'items': [
-              'med_time5'
+              'med_time4'
             ]
           },
           {
             'ehr_list_index': '15',
             'items': [
-              'med_time6'
+              'med_time5'
             ]
           },
           {
             'ehr_list_index': '16',
+            'items': [
+              'med_time6'
+            ]
+          },
+          {
+            'ehr_list_index': '17',
             'items': [
               'med_continuous_description'
             ]
           },
           {
             'label': 'Instructions',
-            'ehr_list_index': '17',
+            'ehr_list_index': '18',
             'items': [
               'med_instructions'
             ]
@@ -13307,7 +13321,8 @@ const DEFS = {
               'gIndex': '4',
               'gChildren': [
                 'med_medication',
-                'med_dose'
+                'med_dose',
+                'med_second_signature'
               ]
             },
             {
@@ -13371,6 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
+            'med_second_signature': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13400,6 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
+          'med_second_signature',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13676,7 +13693,6 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'select',
         'label': 'Status',
-        'mandatory': true,
         'options': [
           {
             'key': 'Administered',
@@ -13703,17 +13719,127 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'mandatory': true,
         'tableColumn': '7',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
+        'elementKey': 'mar_route',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Route',
+        'options': [
+          {
+            'key': 'oral',
+            'text': 'Oral'
+          },
+          {
+            'key': 'bucc',
+            'text': 'Buccal'
+          },
+          {
+            'key': 'cuta',
+            'text': 'Cutaneous'
+          },
+          {
+            'key': 'impl',
+            'text': 'Implant'
+          },
+          {
+            'key': 'inha',
+            'text': 'Inhalation'
+          },
+          {
+            'key': 'inje',
+            'text': 'Injection'
+          },
+          {
+            'key': 'intra',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'nasa',
+            'text': 'Nasal'
+          },
+          {
+            'key': 'nebu',
+            'text': 'Nebulization'
+          },
+          {
+            'key': 'ocul',
+            'text': 'Ocular'
+          },
+          {
+            'key': 'otic',
+            'text': 'Otic'
+          },
+          {
+            'key': 'rect',
+            'text': 'Rectal'
+          },
+          {
+            'key': 'subl',
+            'text': 'Sublingual'
+          },
+          {
+            'key': 'tran',
+            'text': 'Transdermal'
+          },
+          {
+            'key': 'vagi',
+            'text': 'Vaginal'
+          }
+        ],
+        'tableColumn': '8',
+        'fqn': 'medAdminRec.mar_route'
+      },
+      {
+        'elementKey': 'mar_injectionLocation',
+        'formIndex': '2',
+        'inputType': 'select',
+        'label': 'Injection location',
+        'options': [
+          {
+            'key': 'arterial',
+            'text': 'Arterial'
+          },
+          {
+            'key': 'epidural',
+            'text': 'Epidural'
+          },
+          {
+            'key': 'intramuscular',
+            'text': 'Intramuscular'
+          },
+          {
+            'key': 'intraosseous',
+            'text': 'Intraosseous'
+          },
+          {
+            'key': 'intraperitoneal',
+            'text': 'Intraperitoneal'
+          },
+          {
+            'key': 'intrathecal',
+            'text': 'Intrathecal'
+          },
+          {
+            'key': 'intravenous',
+            'text': 'Intravenous'
+          },
+          {
+            'key': 'subcutaneous',
+            'text': 'Subcutaneous'
+          }
+        ],
+        'tableColumn': '9',
+        'fqn': 'medAdminRec.mar_injectionLocation'
+      },
+      {
         'elementKey': 'mar_comments',
         'formIndex': '2',
-        'formCss': 'grid-span-3-columns',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '8',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_comments'
       }
     ],
@@ -13914,6 +14040,18 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
+              'mar_route'
+            ]
+          },
+          {
+            'ehr_list_index': '9',
+            'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '10',
+            'items': [
               'mar_comments'
             ]
           }
@@ -13967,6 +14105,23 @@ const DEFS = {
               'gChildren': [
                 'mar_status',
                 'mar_dose',
+                'mar_route'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_inje',
+              'dependentOn': 'visble:mar_route=inje,intra',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '5',
+              'gChildren': [
+                'mar_injectionLocation'
+              ]
+            },
+            {
+              'elementKey': 'mar_group_notes',
+              'formCss': 'grid-left-to-right-1',
+              'gIndex': '6',
+              'gChildren': [
                 'mar_comments'
               ]
             }
@@ -13985,6 +14140,8 @@ const DEFS = {
             'mo_id': '',
             'mar_status': '',
             'mar_dose': '',
+            'mar_route': '',
+            'mar_injectionLocation': '',
             'mar_comments': ''
           }
         },
@@ -14000,6 +14157,8 @@ const DEFS = {
           'mo_schedTime',
           'mar_status',
           'mar_dose',
+          'mar_route',
+          'mar_injectionLocation',
           'mar_comments'
         ],
         'hasRecHeader': true
@@ -14358,7 +14517,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group371',
+              'elementKey': 'ehr_group370',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14369,7 +14528,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group372',
+              'elementKey': 'ehr_group371',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -14578,7 +14737,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group373',
+              'elementKey': 'ehr_group372',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14589,7 +14748,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group374',
+              'elementKey': 'ehr_group373',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -14752,7 +14911,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group377',
+              'elementKey': 'ehr_group376',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -14763,7 +14922,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group378',
+              'elementKey': 'ehr_group377',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -15986,7 +16145,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group383',
+              'elementKey': 'ehr_group382',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -15997,7 +16156,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group384',
+              'elementKey': 'ehr_group383',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -16130,7 +16289,7 @@ const DEFS = {
           'formKey': 'labResultHematology',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group385',
+              'elementKey': 'ehr_group384',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16141,7 +16300,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group386',
+              'elementKey': 'ehr_group385',
               'label': 'Hematology',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16155,7 +16314,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group387',
+              'elementKey': 'ehr_group386',
               'label': 'WBC Types',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16271,7 +16430,7 @@ const DEFS = {
           'formKey': 'labResultCoagulation',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group388',
+              'elementKey': 'ehr_group387',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16282,7 +16441,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group389',
+              'elementKey': 'ehr_group388',
               'label': 'Coagulation',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16531,7 +16690,7 @@ const DEFS = {
           'formKey': 'labResultGeneral',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group390',
+              'elementKey': 'ehr_group389',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16542,7 +16701,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group391',
+              'elementKey': 'ehr_group390',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16561,7 +16720,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group392',
+              'elementKey': 'ehr_group391',
               'label': 'Renal Profile',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -16572,7 +16731,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group393',
+              'elementKey': 'ehr_group392',
               'label': 'Liver function',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -16588,7 +16747,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group394',
+              'elementKey': 'ehr_group393',
               'label': 'Blood gas tests',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '5',
@@ -16601,7 +16760,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group395',
+              'elementKey': 'ehr_group394',
               'label': 'Group and screen',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '6',
@@ -16739,7 +16898,7 @@ const DEFS = {
           'formKey': 'troponinTable',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group396',
+              'elementKey': 'ehr_group395',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16750,7 +16909,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group397',
+              'elementKey': 'ehr_group396',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -16975,7 +17134,7 @@ const DEFS = {
           'formKey': 'labResultUrine',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group398',
+              'elementKey': 'ehr_group397',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -16986,7 +17145,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group399',
+              'elementKey': 'ehr_group398',
               'label': 'General',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
@@ -16998,7 +17157,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group400',
+              'elementKey': 'ehr_group399',
               'label': 'Chemistry',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
@@ -17024,7 +17183,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group401',
+              'elementKey': 'ehr_group400',
               'label': 'Microsopy',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '4',
@@ -17232,7 +17391,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group379',
+              'elementKey': 'ehr_group378',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17243,7 +17402,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group380',
+              'elementKey': 'ehr_group379',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17397,7 +17556,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group381',
+              'elementKey': 'ehr_group380',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17408,7 +17567,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group382',
+              'elementKey': 'ehr_group381',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -17589,7 +17748,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group402',
+            'elementKey': 'ehr_group401',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17691,7 +17850,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group403',
+            'elementKey': 'ehr_group402',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
             'gChildren': [
@@ -17915,7 +18074,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group404',
+              'elementKey': 'ehr_group403',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -17926,7 +18085,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group405',
+              'elementKey': 'ehr_group404',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18124,7 +18283,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group406',
+              'elementKey': 'ehr_group405',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18135,7 +18294,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group407',
+              'elementKey': 'ehr_group406',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '2',
               'gChildren': [
@@ -18350,7 +18509,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group408',
+              'elementKey': 'ehr_group407',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -18361,7 +18520,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group409',
+              'elementKey': 'ehr_group408',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -18733,11 +18892,11 @@ const DEFS = {
         'fqn': 'testPage.textDateDate'
       },
       {
-        'elementKey': 'spacer415',
+        'elementKey': 'spacer414',
         'formIndex': '3',
         'inputType': 'spacer',
         'label': 'TextDate',
-        'fqn': 'testPage.spacer415'
+        'fqn': 'testPage.spacer414'
       },
       {
         'elementKey': 'name',
@@ -18763,7 +18922,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group410',
+            'elementKey': 'ehr_group409',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-1',
             'gIndex': '1',
@@ -18772,7 +18931,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group411',
+            'elementKey': 'ehr_group410',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '2',
@@ -18790,7 +18949,7 @@ const DEFS = {
             ]
           },
           {
-            'elementKey': 'ehr_group412',
+            'elementKey': 'ehr_group411',
             'label': 'Second group',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '3',
@@ -18868,7 +19027,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group413',
+              'elementKey': 'ehr_group412',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -18897,7 +19056,7 @@ const DEFS = {
         'isPageForm': true,
         'ehr_groups': [
           {
-            'elementKey': 'ehr_group414',
+            'elementKey': 'ehr_group413',
             'label': 'A group label',
             'formCss': 'grid-left-to-right-3',
             'gIndex': '1',
@@ -18908,7 +19067,7 @@ const DEFS = {
               'form2_time',
               'textDate',
               'textDateDate',
-              'spacer415',
+              'spacer414',
               'name',
               'place'
             ]
@@ -19259,13 +19418,13 @@ const DEFS = {
         'fqn': 'testTable.cd1Date'
       },
       {
-        'elementKey': 'spacer421',
+        'elementKey': 'spacer420',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 1',
         'tableColumn': '2',
         'tableLabel': 'Chk 1',
-        'fqn': 'testTable.spacer421'
+        'fqn': 'testTable.spacer420'
       },
       {
         'elementKey': 'cd2',
@@ -19287,13 +19446,13 @@ const DEFS = {
         'fqn': 'testTable.cd2Date'
       },
       {
-        'elementKey': 'spacer422',
+        'elementKey': 'spacer421',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'C D 2',
         'tableColumn': '3',
         'tableLabel': 'Chk 2',
-        'fqn': 'testTable.spacer422'
+        'fqn': 'testTable.spacer421'
       },
       {
         'elementKey': 'td1',
@@ -19314,13 +19473,13 @@ const DEFS = {
         'fqn': 'testTable.td1Date'
       },
       {
-        'elementKey': 'spacer423',
+        'elementKey': 'spacer422',
         'formIndex': '2',
         'inputType': 'spacer',
         'label': 'TextDate',
         'tableColumn': '4',
         'tableLabel': 'Txt 1',
-        'fqn': 'testTable.spacer423'
+        'fqn': 'testTable.spacer422'
       },
       {
         'elementKey': 'referralName',
@@ -19641,7 +19800,7 @@ const DEFS = {
           'formKey': 'table1',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group416',
+              'elementKey': 'ehr_group415',
               'label': 'Group 1',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '1',
@@ -19658,7 +19817,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group417',
+              'elementKey': 'ehr_group416',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -19694,7 +19853,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group418',
+              'elementKey': 'ehr_group417',
               'formOption': '1',
               'formCss': 'full-width',
               'gIndex': '3',
@@ -19774,7 +19933,7 @@ const DEFS = {
             'items': [
               'cd1',
               'cd1Date',
-              'spacer421'
+              'spacer420'
             ]
           },
           {
@@ -19783,7 +19942,7 @@ const DEFS = {
             'items': [
               'cd2',
               'cd2Date',
-              'spacer422'
+              'spacer421'
             ]
           },
           {
@@ -19792,7 +19951,7 @@ const DEFS = {
             'items': [
               'td1',
               'td1Date',
-              'spacer423'
+              'spacer422'
             ]
           },
           {
@@ -19826,7 +19985,7 @@ const DEFS = {
           'formKey': 'stacked',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group419',
+              'elementKey': 'ehr_group418',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -19837,23 +19996,23 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group420',
+              'elementKey': 'ehr_group419',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
                 'cd1',
                 'cd1Date',
-                'spacer421',
+                'spacer420',
                 'cd2',
                 'cd2Date',
-                'spacer422',
+                'spacer421',
                 'td1',
                 'td1Date',
-                'spacer423'
+                'spacer422'
               ]
             },
             {
-              'elementKey': 'ehr_group424',
+              'elementKey': 'ehr_group423',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '3',
               'gChildren': [
@@ -19892,13 +20051,13 @@ const DEFS = {
           'stacked_time',
           'cd1',
           'cd1Date',
-          'spacer421',
+          'spacer420',
           'cd2',
           'cd2Date',
-          'spacer422',
+          'spacer421',
           'td1',
           'td1Date',
-          'spacer423',
+          'spacer422',
           'referralName',
           'referralProfession',
           'appointmentDate',
@@ -26608,7 +26767,7 @@ const DEFS = {
           'formKey': 'table',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group375',
+              'elementKey': 'ehr_group374',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -26619,7 +26778,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group376',
+              'elementKey': 'ehr_group375',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -31770,13 +31929,6 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.form_label362'
       },
       {
-        'elementKey': 'form_label363',
-        'formIndex': '1',
-        'inputType': 'form_label',
-        'label': 'L, H, CH, Cl',
-        'fqn': 'medLabUrinalysis.form_label363'
-      },
-      {
         'elementKey': 'uqcPendAnal_1',
         'formIndex': '1',
         'inputType': 'text',
@@ -31791,150 +31943,46 @@ const DEFS = {
         'fqn': 'medLabUrinalysis.uqcPendResult_1'
       },
       {
-        'elementKey': 'uqcPendFlag_1',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '54',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_1'
-      },
-      {
         'elementKey': 'uqcPendAnal_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '55',
+        'tableColumn': '54',
         'fqn': 'medLabUrinalysis.uqcPendAnal_2'
       },
       {
         'elementKey': 'uqcPendResult_2',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '56',
+        'tableColumn': '55',
         'fqn': 'medLabUrinalysis.uqcPendResult_2'
-      },
-      {
-        'elementKey': 'uqcPendFlag_2',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '57',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_2'
       },
       {
         'elementKey': 'uqcPendAnal_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '58',
+        'tableColumn': '56',
         'fqn': 'medLabUrinalysis.uqcPendAnal_3'
       },
       {
         'elementKey': 'uqcPendResult_3',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '59',
+        'tableColumn': '57',
         'fqn': 'medLabUrinalysis.uqcPendResult_3'
-      },
-      {
-        'elementKey': 'uqcPendFlag_3',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '60',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_3'
       },
       {
         'elementKey': 'uqcPendAnal_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '61',
+        'tableColumn': '58',
         'fqn': 'medLabUrinalysis.uqcPendAnal_4'
       },
       {
         'elementKey': 'uqcPendResult_4',
         'formIndex': '1',
         'inputType': 'text',
-        'tableColumn': '62',
+        'tableColumn': '59',
         'fqn': 'medLabUrinalysis.uqcPendResult_4'
-      },
-      {
-        'elementKey': 'uqcPendFlag_4',
-        'formIndex': '1',
-        'formCss': 'chem-results-lhclch',
-        'inputType': 'radioset',
-        'options': [
-          {
-            'key': 'L',
-            'text': 'L'
-          },
-          {
-            'key': 'H',
-            'text': 'H'
-          },
-          {
-            'key': 'CL',
-            'text': 'CL'
-          },
-          {
-            'key': 'CH',
-            'text': 'CH'
-          }
-        ],
-        'tableColumn': '63',
-        'fqn': 'medLabUrinalysis.uqcPendFlag_4'
       }
     ],
     'pageElements': {
@@ -32325,61 +32373,37 @@ const DEFS = {
           {
             'ehr_list_index': '54',
             'items': [
-              'uqcPendFlag_1'
+              'uqcPendAnal_2'
             ]
           },
           {
             'ehr_list_index': '55',
             'items': [
-              'uqcPendAnal_2'
+              'uqcPendResult_2'
             ]
           },
           {
             'ehr_list_index': '56',
             'items': [
-              'uqcPendResult_2'
+              'uqcPendAnal_3'
             ]
           },
           {
             'ehr_list_index': '57',
             'items': [
-              'uqcPendFlag_2'
+              'uqcPendResult_3'
             ]
           },
           {
             'ehr_list_index': '58',
             'items': [
-              'uqcPendAnal_3'
+              'uqcPendAnal_4'
             ]
           },
           {
             'ehr_list_index': '59',
             'items': [
-              'uqcPendResult_3'
-            ]
-          },
-          {
-            'ehr_list_index': '60',
-            'items': [
-              'uqcPendFlag_3'
-            ]
-          },
-          {
-            'ehr_list_index': '61',
-            'items': [
-              'uqcPendAnal_4'
-            ]
-          },
-          {
-            'ehr_list_index': '62',
-            'items': [
               'uqcPendResult_4'
-            ]
-          },
-          {
-            'ehr_list_index': '63',
-            'items': [
-              'uqcPendFlag_4'
             ]
           }
         ],
@@ -32527,19 +32551,14 @@ const DEFS = {
                 'form_label360',
                 'form_label361',
                 'form_label362',
-                'form_label363',
                 'uqcPendAnal_1',
                 'uqcPendResult_1',
-                'uqcPendFlag_1',
                 'uqcPendAnal_2',
                 'uqcPendResult_2',
-                'uqcPendFlag_2',
                 'uqcPendAnal_3',
                 'uqcPendResult_3',
-                'uqcPendFlag_3',
                 'uqcPendAnal_4',
-                'uqcPendResult_4',
-                'uqcPendFlag_4'
+                'uqcPendResult_4'
               ]
             }
           ],
@@ -32606,16 +32625,12 @@ const DEFS = {
             'uqcSomeQcUnacceptable': '',
             'uqcPendAnal_1': '',
             'uqcPendResult_1': '',
-            'uqcPendFlag_1': '',
             'uqcPendAnal_2': '',
             'uqcPendResult_2': '',
-            'uqcPendFlag_2': '',
             'uqcPendAnal_3': '',
             'uqcPendResult_3': '',
-            'uqcPendFlag_3': '',
             'uqcPendAnal_4': '',
-            'uqcPendResult_4': '',
-            'uqcPendFlag_4': ''
+            'uqcPendResult_4': ''
           }
         },
         'tableChildren': [
@@ -32676,16 +32691,12 @@ const DEFS = {
           'uqcSomeQcUnacceptable',
           'uqcPendAnal_1',
           'uqcPendResult_1',
-          'uqcPendFlag_1',
           'uqcPendAnal_2',
           'uqcPendResult_2',
-          'uqcPendFlag_2',
           'uqcPendAnal_3',
           'uqcPendResult_3',
-          'uqcPendFlag_3',
           'uqcPendAnal_4',
-          'uqcPendResult_4',
-          'uqcPendFlag_4'
+          'uqcPendResult_4'
         ],
         'hasRecHeader': true
       },
@@ -34199,7 +34210,7 @@ const DEFS = {
           'formKey': 'mlAccessioning',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group364',
+              'elementKey': 'ehr_group363',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34210,7 +34221,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group365',
+              'elementKey': 'ehr_group364',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34227,7 +34238,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group366',
+              'elementKey': 'ehr_group365',
               'formCss': 'grid-left-to-right-1',
               'gIndex': '3',
               'gChildren': [
@@ -34344,7 +34355,7 @@ const DEFS = {
           'formKey': 'mlChain',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group367',
+              'elementKey': 'ehr_group366',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34355,7 +34366,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group368',
+              'elementKey': 'ehr_group367',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [
@@ -34461,7 +34472,7 @@ const DEFS = {
           'formKey': 'mlTestStatus',
           'ehr_groups': [
             {
-              'elementKey': 'ehr_group369',
+              'elementKey': 'ehr_group368',
               'formCss': 'record-header',
               'gIndex': '1',
               'gChildren': [
@@ -34472,7 +34483,7 @@ const DEFS = {
               ]
             },
             {
-              'elementKey': 'ehr_group370',
+              'elementKey': 'ehr_group369',
               'formCss': 'grid-left-to-right-3',
               'gIndex': '2',
               'gChildren': [

--- a/server/src/ehr-definitions/ehr-page-defs.js
+++ b/server/src/ehr-definitions/ehr-page-defs.js
@@ -12723,12 +12723,12 @@ const DEFS = {
         'fqn': 'medicationOrders.med_dose'
       },
       {
-        'elementKey': 'med_second_signature',
+        'elementKey': 'med_secondSig',
         'formIndex': '2',
         'inputType': 'checkbox',
-        'label': 'Second signature require',
+        'label': 'Second signature required',
         'tableColumn': '8',
-        'fqn': 'medicationOrders.med_second_signature'
+        'fqn': 'medicationOrders.med_secondSig'
       },
       {
         'elementKey': 'med_scheduled',
@@ -13214,7 +13214,7 @@ const DEFS = {
           {
             'ehr_list_index': '8',
             'items': [
-              'med_second_signature'
+              'med_secondSig'
             ]
           },
           {
@@ -13322,7 +13322,7 @@ const DEFS = {
               'gChildren': [
                 'med_medication',
                 'med_dose',
-                'med_second_signature'
+                'med_secondSig'
               ]
             },
             {
@@ -13386,7 +13386,7 @@ const DEFS = {
             'med_injectionLocation': '',
             'med_medication': '',
             'med_dose': '',
-            'med_second_signature': '',
+            'med_secondSig': '',
             'med_scheduled': '',
             'med_prnMaxDosage': '',
             'med_time1': '',
@@ -13416,7 +13416,7 @@ const DEFS = {
           'med_injectionLocation',
           'med_medication',
           'med_dose',
-          'med_second_signature',
+          'med_secondSig',
           'med_scheduled',
           'med_prnMaxDosage',
           'med_time1',
@@ -13629,7 +13629,7 @@ const DEFS = {
         'formIndex': '2',
         'embedRef': 'medicationOrders.medicationOrdersTable',
         'inputType': 'ehr_embedded',
-        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id]',
+        'passToFunction': '[mo_medOrder mo_timing mo_medInstructions mo_id mo_secondSig]',
         'fqn': 'medAdminRec.med_order_embedded'
       },
       {
@@ -13689,6 +13689,16 @@ const DEFS = {
         'fqn': 'medAdminRec.mo_id'
       },
       {
+        'elementKey': 'mo_secondSig',
+        'calculationType': 'embedValue(medicationOrders, medicationOrdersTable, med_secondSig)',
+        'formIndex': '2',
+        'formCss': 'grid-span-3-columns',
+        'inputType': 'calculatedBool',
+        'label': 'Second signature required',
+        'tableColumn': '6',
+        'fqn': 'medAdminRec.mo_secondSig'
+      },
+      {
         'elementKey': 'mar_status',
         'formIndex': '2',
         'inputType': 'select',
@@ -13711,7 +13721,7 @@ const DEFS = {
             'text': 'Skipped'
           }
         ],
-        'tableColumn': '6',
+        'tableColumn': '7',
         'fqn': 'medAdminRec.mar_status'
       },
       {
@@ -13719,7 +13729,7 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'text',
         'label': 'Dose given',
-        'tableColumn': '7',
+        'tableColumn': '8',
         'fqn': 'medAdminRec.mar_dose'
       },
       {
@@ -13789,7 +13799,7 @@ const DEFS = {
             'text': 'Vaginal'
           }
         ],
-        'tableColumn': '8',
+        'tableColumn': '9',
         'fqn': 'medAdminRec.mar_route'
       },
       {
@@ -13831,7 +13841,7 @@ const DEFS = {
             'text': 'Subcutaneous'
           }
         ],
-        'tableColumn': '9',
+        'tableColumn': '10',
         'fqn': 'medAdminRec.mar_injectionLocation'
       },
       {
@@ -13839,8 +13849,16 @@ const DEFS = {
         'formIndex': '2',
         'inputType': 'textarea',
         'label': 'Comments',
-        'tableColumn': '10',
+        'tableColumn': '11',
         'fqn': 'medAdminRec.mar_comments'
+      },
+      {
+        'elementKey': 'mar_secSigName',
+        'formIndex': '2',
+        'inputType': 'text',
+        'label': 'Second Signature',
+        'tableColumn': '12',
+        'fqn': 'medAdminRec.mar_secSigName'
       }
     ],
     'pageElements': {
@@ -14028,31 +14046,43 @@ const DEFS = {
           {
             'ehr_list_index': '6',
             'items': [
-              'mar_status'
+              'mo_secondSig'
             ]
           },
           {
             'ehr_list_index': '7',
             'items': [
-              'mar_dose'
+              'mar_status'
             ]
           },
           {
             'ehr_list_index': '8',
             'items': [
-              'mar_route'
+              'mar_dose'
             ]
           },
           {
             'ehr_list_index': '9',
             'items': [
-              'mar_injectionLocation'
+              'mar_route'
             ]
           },
           {
             'ehr_list_index': '10',
             'items': [
+              'mar_injectionLocation'
+            ]
+          },
+          {
+            'ehr_list_index': '11',
+            'items': [
               'mar_comments'
+            ]
+          },
+          {
+            'ehr_list_index': '12',
+            'items': [
+              'mar_secSigName'
             ]
           }
         ],
@@ -14094,7 +14124,8 @@ const DEFS = {
                 'mo_timing',
                 'mo_schedDay',
                 'mo_schedTime',
-                'mo_id'
+                'mo_id',
+                'mo_secondSig'
               ]
             },
             {
@@ -14124,6 +14155,15 @@ const DEFS = {
               'gChildren': [
                 'mar_comments'
               ]
+            },
+            {
+              'elementKey': 'mar_group_sec',
+              'dependentOn': 'visble:mo_secondSig',
+              'formCss': 'grid-left-to-right-3',
+              'gIndex': '7',
+              'gChildren': [
+                'mar_secSigName'
+              ]
             }
           ],
           'ehr_data': {
@@ -14138,11 +14178,13 @@ const DEFS = {
             'mo_schedDay': '',
             'mo_schedTime': '',
             'mo_id': '',
+            'mo_secondSig': '',
             'mar_status': '',
             'mar_dose': '',
             'mar_route': '',
             'mar_injectionLocation': '',
-            'mar_comments': ''
+            'mar_comments': '',
+            'mar_secSigName': ''
           }
         },
         'tableChildren': [
@@ -14155,11 +14197,13 @@ const DEFS = {
           'mo_timing',
           'mo_schedDay',
           'mo_schedTime',
+          'mo_secondSig',
           'mar_status',
           'mar_dose',
           'mar_route',
           'mar_injectionLocation',
-          'mar_comments'
+          'mar_comments',
+          'mar_secSigName'
         ],
         'hasRecHeader': true
       }

--- a/server/src/ehr-definitions/ehr-types.js
+++ b/server/src/ehr-definitions/ehr-types.js
@@ -23,6 +23,7 @@ const EhrTypes = {
     checkbox: 'checkbox',
     boxcheckset: 'boxcheckset',
     select: 'select',
+    calculatedBool: 'calculatedBool',
     calculatedText: 'calculatedText',
     calculatedValue: 'calculatedValue',
     checkset: 'checkset',

--- a/server/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/server/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -65,7 +65,6 @@ export class MedOrder {
    * @returns {string}
    */
   medOrderSummary () {
-    console.log('mmos', this._e)
     const list = []
     list.push(this.medName)
     list.push(this.dose)

--- a/server/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/server/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -1,5 +1,6 @@
 import { MED_ORDERS_PAGE_KEY, MED_ORDERS_TABLE_KEY } from '../ehr-defs-grid'
 import { hourStringToHour } from './mar-model'
+import { makeHumanTableCell } from '../ehr-def-utils'
 
 export class MedOrders {
   constructor (ehrDataModel) {
@@ -26,12 +27,15 @@ export class MedOrders {
 export class MedOrder {
   constructor (eData) {
     this._e = {}
-    const {med_dose, medicationOrdersTable_id, med_instructions, med_injectionLocation,
+    let {med_dose, medicationOrdersTable_id, med_instructions, med_injectionLocation,
       med_scheduled,
       med_prnMaxDosage, med_medication,
       med_reason, med_route, med_timing,
       med_time1, med_time2, med_time3, med_time4, med_time5, med_time6
     } = eData
+    // translate the key data into human readable
+    med_route = makeHumanTableCell( 'medicationOrders', 'med_route', 'select', med_route)
+    med_injectionLocation = makeHumanTableCell( 'medicationOrders', 'med_injectionLocation', 'select', med_injectionLocation)
     this._e.day = eData['medicationOrdersTable_day']
     this._e.time = eData['medicationOrdersTable_time']
     this._e.name = eData['medicationOrdersTable_name']
@@ -61,12 +65,14 @@ export class MedOrder {
    * @returns {string}
    */
   medOrderSummary () {
+    console.log('mmos', this._e)
     const list = []
     list.push(this.medName)
     list.push(this.dose)
-    list.push(this.route)
     list.push(this.schedule)
-    return list.join(' ')
+    list.push(this.route)
+    list.push(this.location)
+    return list.join(', ')
   }
 
   /**


### PR DESCRIPTION
EhrOnlyDemo with mPatient fixed. Just needed to push the seed id into the mPatient store to be able to get the seed data

update the EHR only demo case study #2

MAR's summary of the med order

- include any injection location
- make the route and location human readable

Fix checkboxes on Chrome to remove extra line

EHR content updates

- MedLab Urinalysis, remove L,H,CL,CH options
- MED add second signature
MAR - remove mandatories until we do barscan checks. (nurses need to prepare the mar and then administer)
- make med order human readable
- add route and injection site to MAR

Calculated Bool -- to allow Med Orders to set 2nd sig req'd on MAR

Up EHR content

Med Order with 2nd Sig req'd
MAR with route, injection site, 2nd sig