### PR TITLE
Fix defects - Better LObj export import

### DIFF
--- a/client/src/directives/text-to-html.js
+++ b/client/src/directives/text-to-html.js
@@ -18,6 +18,8 @@ function worker (el, binding, source) {
     if (debug) console.log('T2H directive binding', binding.value)
     el.innerHTML = textToHtml(binding.value, binding.modifiers.noAutoLink)
     if (debug) console.log('T2H el.innerHTML', el.innerHTML)
+  } else {
+    el.innerHTML = ''
   }
 }
 

--- a/client/src/helpers/ehr-utils.js
+++ b/client/src/helpers/ehr-utils.js
@@ -312,7 +312,7 @@ export function downloadEhrOnlyToFile ( ehrData, fName) {
   if (debug) console.log('EhrUtil Download EHR only to ', fName, ehrData)
   _saveAs(data, fName, mJSON)
 }
-export function downloadLearningObjectToFile (learningObject) {
+export function downloadLearningObjectToFile (learningObject, seedObject) {
   let lastUpdate = formatDateStr(learningObject.lastUpdateDate)
   let name = learningObject.name
   let ver = learningObject.version
@@ -322,11 +322,13 @@ export function downloadLearningObjectToFile (learningObject) {
     + '.json'
   let data = {
     id: learningObject._id,
+    appType: learningObject.appType,
     license: Text.LICENSE_FULL_TEXT,
     description: learningObject.description,
     name: name,
     version: ver,
-    fileName: fName
+    fileName: fName,
+    caseStudy: seedObject
   }
   data = JSON.stringify(data, null, 2)
   if (debug) console.log('EhrUtil Download learning object to ', fName)

--- a/client/src/helpers/mPatientHelper.js
+++ b/client/src/helpers/mPatientHelper.js
@@ -45,10 +45,11 @@ class MPatientHelperWorker {
 
   sortPatientList (list) {
     const getName = (p) => {
-      return p.keyData ? p.keyData.familyName || {} : ''
+      return p.keyData ? p.keyData.familyName : undefined
     }
     list.sort((a, b) => {
-      return getName(a).localeCompare(getName(b))
+      let aName = getName(a) || ''
+      return aName.localeCompare(getName(b))
     })
   }
 

--- a/client/src/outside/components/learning-object/LearningObjectActions.vue
+++ b/client/src/outside/components/learning-object/LearningObjectActions.vue
@@ -50,8 +50,9 @@ export default {
     learningObjectId () { return this.learningObject._id}
   },
   methods: {
-    downloadLearningObject () {
-      downloadLearningObjectToFile(this.learningObject)
+    async downloadLearningObject () {
+      const seed = await this.$store.dispatch('seedListStore/fetchSeed', this.learningObject.seedDataId)
+      downloadLearningObjectToFile(this.learningObject, seed)
     },
     gotoLearningObjectView () {
       this.$router.push({ name: 'learning-object', query: { learningObjectId: this.learningObjectId } })

--- a/client/src/store/modules/seedListStore.js
+++ b/client/src/store/modules/seedListStore.js
@@ -73,6 +73,14 @@ const actions = {
     })
   },
 
+  async fetchSeed (context, seedId) {
+    if (debugSL) console.log('SeedList fetchSeed', seedId)
+    let url = 'get/' + seedId
+    return InstoreHelper.getRequest(context, API, url).then(response => {
+      return response.data.seeddata
+    })
+  },
+
   /**
    * Load a seed record and set seed id as current seed
    * @param context

--- a/server/src/server/trace-api.js
+++ b/server/src/server/trace-api.js
@@ -55,24 +55,19 @@ function composeData (req, statusCode, time) {
     .replace(/[:.]/g, '')
     .replace(/\//g, '_')
   const elapsedMs = Math.round(time)
-  const rec = {
-    key: key,
-    ts: ts,
-    tsStr: (new Date(ts)).toISOString(),
-    elapsedMs: elapsedMs,
-    status: statusCode,
-  }
+  const rec = { }
+  rec.consumerKey = req.consumerKey
+  rec.userId = req.userId
+  rec.visitId = req.visitId // req.authPayload ? req.authPayload.visitId : undefined
+  rec.key = key
+  rec.elapsedMs = elapsedMs
+  rec.isPrimary = req.isPrimary
+  rec.status = statusCode
   rec.origin = req.headers['origin'] || req.url
   rec.params = isNotEmpty(req.params) ? req.params : undefined
   rec.query = isNotEmpty(req.query) ? req.query : undefined
-  // yes stash the visit id in the trace log.
-  // Need it to follow the actions on a student's work to ensure the student's work is preserved in the db as they entered it.
-  // The users are reporting strange events. To determine the cause after the fact we need this information.
-  rec.visitId = req.visitId // req.authPayload ? req.authPayload.visitId : undefined
-  rec.consumerKey = req.consumerKey
-  rec.isPrimary = req.isPrimary
-  rec.userId = req.userId
-
+  rec.tsStr = (new Date(ts)).toISOString()
+  rec.ts = ts
   const includeBody = false
   if (includeBody && isNotEmpty(req.body)) {
     rec.body = Object.assign({}, req.body)


### PR DESCRIPTION
The v-text-to-html directive was keeping previous data if the new content was empty.
The mPatient tab sorting hit a problem when a seed was yet to get a patient name.
Tracing on the server is reorganized to allow easier visual sorting.
Exporting of LObjs now include the seed.
