### PR TITLE
MAR page rework a new design

### DIFF
--- a/client/src/ehr-definitions/med-definitions/mar-model.js
+++ b/client/src/ehr-definitions/med-definitions/mar-model.js
@@ -9,6 +9,11 @@ export const MED_GROUP_PRN = 'prn'
 export const MED_GROUP_STAT = 'stat'
 export const MED_GROUP_CONT = 'cont'
 
+export const MAR_STATUS_ADMINISTERED = 'Administered'
+export const MAR_STATUS_REFUSED = 'Refused'
+export const MAR_STATUS_SKIPPED = 'Skipped'
+export const MAR_STATUS_MISSED = 'Missed'
+
 // for use by UI
 export const MED_GROUPS = [MED_GROUP_SCHED, MED_GROUP_STAT, MED_GROUP_PRN, MED_GROUP_OD, MED_GROUP_ONCE, MED_GROUP_CONT]
 // for use by UI
@@ -34,7 +39,7 @@ export class MarTimelineModel {
     this._numberOfDays = simTime.visitDay === 0 ? 2 : simTime.visitDay + 1
     const dayNumbersArray = [...Array(this._numberOfDays).keys()]
     this._timeline.days = dayNumbersArray.map(d => {
-      return new TimeLineDay(d, this.medOrders, this.marRecords)
+      return new TimeLineDay(d, this.medOrders, this._numberOfDays)
     })
     this.setupMedMarEvents()
   }
@@ -143,10 +148,26 @@ export class MarTimelineModel {
  * Provide the desired group (idPrefix) to get the set of medications rows for that group.
  */
 export class TimeLineDay {
-  constructor (dayNumber, medOrders) {
+  constructor (dayNumber, medOrders, maxDays) {
+    // console.log('constructing time line day', dayNumber, maxDays)
+    const todayNum = maxDays - 1
     this.dayId = 'day-' + dayNumber
     this.dayNum = dayNumber
-    this.label= 'day ' + dayNumber
+    let dv = new Date()
+    let df = todayNum-dayNumber
+    dv.setDate(dv.getDate() - df)
+    this.dateStr = dv.toISOString().split('T')[0]
+    let lbl
+    if ( dayNumber === todayNum) {
+      lbl = 'Today'
+      df = 0
+    } else if ( dayNumber === todayNum - 1) {
+      lbl = 'Yesterday'
+      df = 1
+    } else if ( dayNumber < todayNum - 1) {
+      lbl = (todayNum-dayNumber) + ' days ago'
+    }
+    this.label= lbl
     this.medOrders = medOrders
     this.timeElementLabels = DAY_TEMPLATE.map(ts => {
       return {

--- a/client/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/client/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -68,9 +68,9 @@ export class MedOrder {
     const list = []
     list.push(this.medName)
     list.push(this.dose)
-    list.push(this.schedule)
-    list.push(this.route)
-    list.push(this.location)
+    this.schedule ? list.push(this.schedule) : null
+    this.route ? list.push(this.route) : null
+    this.location ? list.push(this.location) : null
     return list.join(', ')
   }
 

--- a/client/src/ehr-definitions/med-definitions/mm-event.js
+++ b/client/src/ehr-definitions/med-definitions/mm-event.js
@@ -17,6 +17,7 @@ export class MedMarEvent {
     this.marIsDraft = undefined
     this.marRecord = undefined
     this.marRecordId = undefined
+    this.marStatus = undefined
   }
   setMar (mar) {
     this.adminDay = mar.day
@@ -24,11 +25,12 @@ export class MedMarEvent {
     this.marIsDraft = !!mar.isDraft
     this.marRecord = mar
     this.marRecordId = mar.id
+    this.marStatus = mar.status
   }
   // TODO rewrite the toolTip to be more user friendly and not, as it is now, written for a developer.
   get toolTip () { return this.toString() }
   toString () {
-    return `${this.adminDay} ${this.adminTime} ${this.marRecordId} ${this.medOrderId} ${this.schedDay} ${this.schedTime}.`
+    return `${this.adminDay} ${this.adminTime} ${this.marStatus} ${this.marRecordId} ${this.medOrderId} ${this.schedDay} ${this.schedTime}.`
   }
 
   get schedDay () { return this._schedDay}
@@ -36,6 +38,7 @@ export class MedMarEvent {
   get medOrderId () { return this._medOrderId}
   // get marRecordId () { return this.marRecord}
   hasMar () { return !!this.marRecord }
+  marStatus () { return this.marStatus }
   hasMarEvent () { return this.hasMar() && !this.marIsDraft }
   hasScheduledEvent () { return this.marIsDraft || this.marRecordId === undefined }
   hasDraftMar () { return this.marIsDraft}

--- a/client/src/inside/components/mar/MarTabs.vue
+++ b/client/src/inside/components/mar/MarTabs.vue
@@ -7,7 +7,13 @@
       tab(name="V1 Summary", v-if='showV1')
         mar-summary(:ehrHelp="ehrHelp")
       tab(name="MAR")
-        //p {{v2Message}}
+        div(class='day-selector-bar flow_across')
+          div(class="day-selector", v-for='aDay in dayList', :key='aDay.dayId')
+            ui-button(
+              :class='{daySelectorSelected: aDay.dayNum === selectedDay}'
+              v-on:buttonClicked="setSelectedDay(aDay.dayNum)",
+            )
+              span {{dayWords(aDay)}}
         mar-med-grid(
           v-for="prefix in groups",
           :ehrHelp="ehrHelp"
@@ -42,6 +48,7 @@ import EhrPageElement from '@/inside/components/page/EhrPageElement.vue'
 import StoreHelper from '@/helpers/store-helper'
 import EventBus, { PAGE_DATA_REFRESH_EVENT } from '@/helpers/event-bus'
 import EhrData from '@/inside/components/page/ehr-data'
+import UiButton from '@/app/ui/UiButton.vue'
 
 export default {
   data () {
@@ -56,6 +63,7 @@ export default {
     }
   },
   components: {
+    UiButton,
     EhrPageElement,
     EhrDialogForm,
     MarMedGrid,
@@ -80,6 +88,8 @@ export default {
   },
   computed: {
     activeTab () { return this.$store.getters['ehrPageTab/activeTab'](this.pageDataKey) },
+    timeLineDays () { return this.timeLineModel.timeLineDays || [] },
+    dayList () { return this.timeLineDays.slice().sort( (a,b) => b.dayNum - a.dayNum ) },
     todayTabName () {
       return 'Day ' + this.marToday.getCurrentDay()
     },
@@ -104,6 +114,9 @@ export default {
     // timeLineModel () { return new MarTimelineModel(this.ehrDataModel)}
   },
   methods: {
+    dayWords (aDay) {
+      return aDay.label
+    },
     // v2
     setSelectedDay (dN) {
       this.selectedDay = dN
@@ -123,9 +136,10 @@ export default {
     },
   },
   // v2
-  mounted () { this.setupTimeline() },
+  mounted () {  },
   created: function () {
     this.marToday = new MarToday()
+    this.setupTimeline()
     const _this = this
     this.refreshEventHandler = function () { _this.setupTimeline() }
     EventBus.$on(PAGE_DATA_REFRESH_EVENT, this.refreshEventHandler)
@@ -138,3 +152,16 @@ export default {
 
 }
 </script>
+
+<style lang="scss" scoped>
+@import '../../../scss/definitions';
+
+.day-selector {
+  //border: 1px solid black;
+  padding: 5px;
+  .daySelectorSelected {
+    background-color: $grey20;
+    cursor: inherit;
+  }
+}
+</style>

--- a/client/src/scss/_definitions.scss
+++ b/client/src/scss/_definitions.scss
@@ -19,6 +19,7 @@ $app-tag-button-colour: $brand-primary-dark;
 $app-tag-button-hover-colour: $brand-highlight-red;
 
 $brand-primary-hover: $brand-highlight-light;
+$brand-selected: $brand-highlight-light;
 
 $button-border-radius: 3px;
 

--- a/ehr-workspace/src/ehr-definitions/med-definitions/mar-model.js
+++ b/ehr-workspace/src/ehr-definitions/med-definitions/mar-model.js
@@ -9,6 +9,11 @@ export const MED_GROUP_PRN = 'prn'
 export const MED_GROUP_STAT = 'stat'
 export const MED_GROUP_CONT = 'cont'
 
+export const MAR_STATUS_ADMINISTERED = 'Administered'
+export const MAR_STATUS_REFUSED = 'Refused'
+export const MAR_STATUS_SKIPPED = 'Skipped'
+export const MAR_STATUS_MISSED = 'Missed'
+
 // for use by UI
 export const MED_GROUPS = [MED_GROUP_SCHED, MED_GROUP_STAT, MED_GROUP_PRN, MED_GROUP_OD, MED_GROUP_ONCE, MED_GROUP_CONT]
 // for use by UI
@@ -34,7 +39,7 @@ export class MarTimelineModel {
     this._numberOfDays = simTime.visitDay === 0 ? 2 : simTime.visitDay + 1
     const dayNumbersArray = [...Array(this._numberOfDays).keys()]
     this._timeline.days = dayNumbersArray.map(d => {
-      return new TimeLineDay(d, this.medOrders, this.marRecords)
+      return new TimeLineDay(d, this.medOrders, this._numberOfDays)
     })
     this.setupMedMarEvents()
   }
@@ -143,10 +148,26 @@ export class MarTimelineModel {
  * Provide the desired group (idPrefix) to get the set of medications rows for that group.
  */
 export class TimeLineDay {
-  constructor (dayNumber, medOrders) {
+  constructor (dayNumber, medOrders, maxDays) {
+    // console.log('constructing time line day', dayNumber, maxDays)
+    const todayNum = maxDays - 1
     this.dayId = 'day-' + dayNumber
     this.dayNum = dayNumber
-    this.label= 'day ' + dayNumber
+    let dv = new Date()
+    let df = todayNum-dayNumber
+    dv.setDate(dv.getDate() - df)
+    this.dateStr = dv.toISOString().split('T')[0]
+    let lbl
+    if ( dayNumber === todayNum) {
+      lbl = 'Today'
+      df = 0
+    } else if ( dayNumber === todayNum - 1) {
+      lbl = 'Yesterday'
+      df = 1
+    } else if ( dayNumber < todayNum - 1) {
+      lbl = (todayNum-dayNumber) + ' days ago'
+    }
+    this.label= lbl
     this.medOrders = medOrders
     this.timeElementLabels = DAY_TEMPLATE.map(ts => {
       return {

--- a/ehr-workspace/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/ehr-workspace/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -68,9 +68,9 @@ export class MedOrder {
     const list = []
     list.push(this.medName)
     list.push(this.dose)
-    list.push(this.schedule)
-    list.push(this.route)
-    list.push(this.location)
+    this.schedule ? list.push(this.schedule) : null
+    this.route ? list.push(this.route) : null
+    this.location ? list.push(this.location) : null
     return list.join(', ')
   }
 

--- a/ehr-workspace/src/ehr-definitions/med-definitions/mm-event.js
+++ b/ehr-workspace/src/ehr-definitions/med-definitions/mm-event.js
@@ -17,6 +17,7 @@ export class MedMarEvent {
     this.marIsDraft = undefined
     this.marRecord = undefined
     this.marRecordId = undefined
+    this.marStatus = undefined
   }
   setMar (mar) {
     this.adminDay = mar.day
@@ -24,11 +25,12 @@ export class MedMarEvent {
     this.marIsDraft = !!mar.isDraft
     this.marRecord = mar
     this.marRecordId = mar.id
+    this.marStatus = mar.status
   }
   // TODO rewrite the toolTip to be more user friendly and not, as it is now, written for a developer.
   get toolTip () { return this.toString() }
   toString () {
-    return `${this.adminDay} ${this.adminTime} ${this.marRecordId} ${this.medOrderId} ${this.schedDay} ${this.schedTime}.`
+    return `${this.adminDay} ${this.adminTime} ${this.marStatus} ${this.marRecordId} ${this.medOrderId} ${this.schedDay} ${this.schedTime}.`
   }
 
   get schedDay () { return this._schedDay}
@@ -36,6 +38,7 @@ export class MedMarEvent {
   get medOrderId () { return this._medOrderId}
   // get marRecordId () { return this.marRecord}
   hasMar () { return !!this.marRecord }
+  marStatus () { return this.marStatus }
   hasMarEvent () { return this.hasMar() && !this.marIsDraft }
   hasScheduledEvent () { return this.marIsDraft || this.marRecordId === undefined }
   hasDraftMar () { return this.marIsDraft}

--- a/server/src/ehr-definitions/med-definitions/mar-model.js
+++ b/server/src/ehr-definitions/med-definitions/mar-model.js
@@ -9,6 +9,11 @@ export const MED_GROUP_PRN = 'prn'
 export const MED_GROUP_STAT = 'stat'
 export const MED_GROUP_CONT = 'cont'
 
+export const MAR_STATUS_ADMINISTERED = 'Administered'
+export const MAR_STATUS_REFUSED = 'Refused'
+export const MAR_STATUS_SKIPPED = 'Skipped'
+export const MAR_STATUS_MISSED = 'Missed'
+
 // for use by UI
 export const MED_GROUPS = [MED_GROUP_SCHED, MED_GROUP_STAT, MED_GROUP_PRN, MED_GROUP_OD, MED_GROUP_ONCE, MED_GROUP_CONT]
 // for use by UI
@@ -34,7 +39,7 @@ export class MarTimelineModel {
     this._numberOfDays = simTime.visitDay === 0 ? 2 : simTime.visitDay + 1
     const dayNumbersArray = [...Array(this._numberOfDays).keys()]
     this._timeline.days = dayNumbersArray.map(d => {
-      return new TimeLineDay(d, this.medOrders, this.marRecords)
+      return new TimeLineDay(d, this.medOrders, this._numberOfDays)
     })
     this.setupMedMarEvents()
   }
@@ -143,10 +148,26 @@ export class MarTimelineModel {
  * Provide the desired group (idPrefix) to get the set of medications rows for that group.
  */
 export class TimeLineDay {
-  constructor (dayNumber, medOrders) {
+  constructor (dayNumber, medOrders, maxDays) {
+    // console.log('constructing time line day', dayNumber, maxDays)
+    const todayNum = maxDays - 1
     this.dayId = 'day-' + dayNumber
     this.dayNum = dayNumber
-    this.label= 'day ' + dayNumber
+    let dv = new Date()
+    let df = todayNum-dayNumber
+    dv.setDate(dv.getDate() - df)
+    this.dateStr = dv.toISOString().split('T')[0]
+    let lbl
+    if ( dayNumber === todayNum) {
+      lbl = 'Today'
+      df = 0
+    } else if ( dayNumber === todayNum - 1) {
+      lbl = 'Yesterday'
+      df = 1
+    } else if ( dayNumber < todayNum - 1) {
+      lbl = (todayNum-dayNumber) + ' days ago'
+    }
+    this.label= lbl
     this.medOrders = medOrders
     this.timeElementLabels = DAY_TEMPLATE.map(ts => {
       return {

--- a/server/src/ehr-definitions/med-definitions/medOrder-model.js
+++ b/server/src/ehr-definitions/med-definitions/medOrder-model.js
@@ -68,9 +68,9 @@ export class MedOrder {
     const list = []
     list.push(this.medName)
     list.push(this.dose)
-    list.push(this.schedule)
-    list.push(this.route)
-    list.push(this.location)
+    this.schedule ? list.push(this.schedule) : null
+    this.route ? list.push(this.route) : null
+    this.location ? list.push(this.location) : null
     return list.join(', ')
   }
 

--- a/server/src/ehr-definitions/med-definitions/mm-event.js
+++ b/server/src/ehr-definitions/med-definitions/mm-event.js
@@ -17,6 +17,7 @@ export class MedMarEvent {
     this.marIsDraft = undefined
     this.marRecord = undefined
     this.marRecordId = undefined
+    this.marStatus = undefined
   }
   setMar (mar) {
     this.adminDay = mar.day
@@ -24,11 +25,12 @@ export class MedMarEvent {
     this.marIsDraft = !!mar.isDraft
     this.marRecord = mar
     this.marRecordId = mar.id
+    this.marStatus = mar.status
   }
   // TODO rewrite the toolTip to be more user friendly and not, as it is now, written for a developer.
   get toolTip () { return this.toString() }
   toString () {
-    return `${this.adminDay} ${this.adminTime} ${this.marRecordId} ${this.medOrderId} ${this.schedDay} ${this.schedTime}.`
+    return `${this.adminDay} ${this.adminTime} ${this.marStatus} ${this.marRecordId} ${this.medOrderId} ${this.schedDay} ${this.schedTime}.`
   }
 
   get schedDay () { return this._schedDay}
@@ -36,6 +38,7 @@ export class MedMarEvent {
   get medOrderId () { return this._medOrderId}
   // get marRecordId () { return this.marRecord}
   hasMar () { return !!this.marRecord }
+  marStatus () { return this.marStatus }
   hasMarEvent () { return this.hasMar() && !this.marIsDraft }
   hasScheduledEvent () { return this.marIsDraft || this.marRecordId === undefined }
   hasDraftMar () { return this.marIsDraft}


### PR DESCRIPTION
Remove the vertical day selector bars that no one could understand.
Replace with straight forward day selection buttons.
Also show the full date string calculated based on today and the simulation's encounter date
Provide info popup for each medication
Style MAR done button based on mar status
Let user select rows on MAR just to highlight the active row